### PR TITLE
Fix lmn_dump_link_json.

### DIFF
--- a/src/vm/dumper.c
+++ b/src/vm/dumper.c
@@ -1080,7 +1080,7 @@ static void lmn_dump_link_json(LmnSymbolAtomRef atom, int index)
         break;
       case LMN_SP_ATOM_ATTR:
       case LMN_CONST_STR_ATTR:
-        fprintf(stdout, "\"data\":%s", lmn_string_c_str((LmnStringRef)data));
+        fprintf(stdout, "\"data\":\"\\\"%s\\\"\"", lmn_string_c_str((LmnStringRef)data));
         break;
       case LMN_HL_ATTR:
         {


### PR DESCRIPTION
Resolve the issue that Graphene does not draw string atoms.