### PR TITLE
Fix integer.set

### DIFF
--- a/src/ext/integer.cpp
+++ b/src/ext/integer.cpp
@@ -78,10 +78,11 @@ void integer_set(LmnReactCxtRef rc,
                  LmnAtomRef a2, LmnLinkAttr t2)
 {
   Vector *srcvec;
-  LmnWord i, n, start, end;
+  LmnWord i;
+  long long n, start, end;
 
-  start  = (LmnWord)a0;
-  end    = (LmnWord)a1;
+  start  = (long long)a0;
+  end    = (long long)a1;
   srcvec = vec_make(16);
   vec_push(srcvec, (LmnWord)LinkObj_make(a2, t2));
 

--- a/test/library_check/Makefile.am
+++ b/test/library_check/Makefile.am
@@ -3,10 +3,12 @@ LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) \
                   $(top_srcdir)/test/tap-driver.sh
 
 TESTS = \
+	testsuite/integer/check.sh \
 	testsuite/set/check.sh \
 	testsuite/statespace/check.sh
 
 check_DATA = \
+	testsuite/integer/integer_set.il \
 	testsuite/set/set.il \
 	testsuite/statespace/statespace.il
 

--- a/test/library_check/testsuite/integer/check.sh
+++ b/test/library_check/testsuite/integer/check.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+../../src/slim -I../../lib testsuite/integer/integer_set.il

--- a/test/library_check/testsuite/integer/integer_set.lmn
+++ b/test/library_check/testsuite/integer/integer_set.lmn
@@ -1,0 +1,74 @@
+
+unit_test.use.
+
+tap_producer = {
+  test_suite = {
+    setup = { integer.use. }.
+
+    test_case = {
+      name = "integer.set case 1".
+
+      init = { n = integer.set(0, 3) }.
+
+      ruleset = {}.
+
+      stable = {
+        n(0), n(1), n(2), n(3).
+      }.
+    }.
+
+    teardown = { integer.use :- . rules({@p}) :- . }
+  }.
+
+  test_suite = {
+    setup = { integer.use. }.
+
+    test_case = {
+      name = "integer.set case 2".
+
+      init = { n = integer.set(-2, -1) }.
+
+      ruleset = {}.
+
+      stable = {
+        n(-2), n(-1).
+      }.
+    }.
+
+    teardown = { integer.use :- . rules({@p}) :- . }
+  }.
+
+  test_suite = {
+    setup = { integer.use. }.
+
+    test_case = {
+      name = "integer.set case 3".
+
+      init = { n = integer.set(-2, 2) }.
+
+      ruleset = {}.
+
+      stable = {
+        n(-2), n(-1), n(0), n(1), n(2).
+      }.
+    }.
+
+    teardown = { integer.use :- . rules({@p}) :- . }
+  }.
+
+  test_suite = {
+    setup = { integer.use. }.
+
+    test_case = {
+      name = "integer.set case 4".
+
+      init = { n = integer.set(2, -2) }.
+
+      ruleset = {}.
+
+      stable = {}.
+    }.
+
+    teardown = { integer.use :- . rules({@p}) :- . }
+  }.
+}.


### PR DESCRIPTION
* `integer.set` の引数に負数を与えると正しく動かないバグを修正。
  + 内部のループ変数が `LmnWord`型（unsigned）になっていたことが原因。
  + `LmnWord` 型から `long long` 型に変更して対応。
* 例1: `n=integer.set(-2,-1).`
  + 期待される出力： `n(-2). n(-1). @45.`
  + 実際の出力： `@45.`
* 例2: `n=integer.set(-2,2).`
  + 期待される出力： `n(-2). n(-1). n(0). n(1). n(2). @45.`
  + 実際の出力： `@45.`
* 例2: `n=integer.set(2,-2).`
  + 期待される出力： `@45.`
  + 実際の出力： 1分以上経っても応答がない。
* なお、ここでの出力とは `slim --use-builtin-rule hoge.il`の実行結果を指す。