### PR TITLE
Refactor/LmnFunctorTable

### DIFF
--- a/src/element/alloc.cpp
+++ b/src/element/alloc.cpp
@@ -64,7 +64,7 @@ void mpool_init() {
 LmnSymbolAtomRef lmn_new_atom(LmnFunctor f) {
   LmnSymbolAtomRef ap;
   int arity, cid;
-  arity = LMN_FUNCTOR_ARITY(f);
+  arity = LMN_FUNCTOR_ARITY(lmn_functor_table, f);
   cid = env_my_thread_id();
 
   if (atom_memory_pools[arity][cid] == 0) {
@@ -82,7 +82,7 @@ void lmn_delete_atom(LmnSymbolAtomRef ap) {
 
   env_return_id(ap->get_id());
 
-  arity = LMN_FUNCTOR_ARITY(ap->get_functor());
+  arity = LMN_FUNCTOR_ARITY(lmn_functor_table, ap->get_functor());
   cid = env_my_thread_id();
   memory_pool_free(atom_memory_pools[arity][cid], ap);
 }

--- a/src/element/port.cpp
+++ b/src/element/port.cpp
@@ -492,7 +492,7 @@ void cb_port_getc(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
     sprintf(buf, "eof");
   else
     sprintf(buf, "%c", c);
-  a = lmn_new_atom(lmn_functor_table.intern(ANONYMOUS, lmn_intern(buf), 1));
+  a = lmn_new_atom(lmn_functor_table->intern(ANONYMOUS, lmn_intern(buf), 1));
   mem_push_symbol_atom(mem, (LmnSymbolAtomRef)a);
   lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), a, LMN_ATTR_MAKE_LINK(0),
                   0);
@@ -692,7 +692,7 @@ void cb_port_output_string(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
     lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), s, LMN_STRING_ATTR, 0);
   } else {
     LmnSAtom a = lmn_mem_newatom(
-        mem, lmn_functor_table.intern(ANONYMOUS, lmn_intern("error"), 1));
+        mem, lmn_functor_table->intern(ANONYMOUS, lmn_intern("error"), 1));
     lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), a,
                     LMN_ATTR_MAKE_LINK(0), 0);
   }
@@ -722,7 +722,7 @@ void sp_cb_port_dump(void *data, LmnPortRef port) {
 BOOL sp_cp_port_is_ground(void *data) { return FALSE; }
 
 void port_init() {
-  eof_functor = lmn_functor_table.intern(ANONYMOUS, lmn_intern("eof"), 1);
+  eof_functor = lmn_functor_table->intern(ANONYMOUS, lmn_intern("eof"), 1);
 
   port_atom_type = lmn_sp_atom_register("port", sp_cb_port_copy,
                                         sp_cb_port_free, sp_cb_port_eq,

--- a/src/element/port.cpp
+++ b/src/element/port.cpp
@@ -492,7 +492,7 @@ void cb_port_getc(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
     sprintf(buf, "eof");
   else
     sprintf(buf, "%c", c);
-  a = lmn_new_atom(lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern(buf), 1));
+  a = lmn_new_atom(lmn_functor_table.intern(ANONYMOUS, lmn_intern(buf), 1));
   mem_push_symbol_atom(mem, (LmnSymbolAtomRef)a);
   lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), a, LMN_ATTR_MAKE_LINK(0),
                   0);
@@ -692,7 +692,7 @@ void cb_port_output_string(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
     lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), s, LMN_STRING_ATTR, 0);
   } else {
     LmnSAtom a = lmn_mem_newatom(
-        mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("error"), 1));
+        mem, lmn_functor_table.intern(ANONYMOUS, lmn_intern("error"), 1));
     lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), a,
                     LMN_ATTR_MAKE_LINK(0), 0);
   }
@@ -722,7 +722,7 @@ void sp_cb_port_dump(void *data, LmnPortRef port) {
 BOOL sp_cp_port_is_ground(void *data) { return FALSE; }
 
 void port_init() {
-  eof_functor = lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("eof"), 1);
+  eof_functor = lmn_functor_table.intern(ANONYMOUS, lmn_intern("eof"), 1);
 
   port_atom_type = lmn_sp_atom_register("port", sp_cb_port_copy,
                                         sp_cb_port_free, sp_cb_port_eq,

--- a/src/element/port.cpp
+++ b/src/element/port.cpp
@@ -492,7 +492,7 @@ void cb_port_getc(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
     sprintf(buf, "eof");
   else
     sprintf(buf, "%c", c);
-  a = lmn_new_atom(lmn_functor_intern(ANONYMOUS, lmn_intern(buf), 1));
+  a = lmn_new_atom(lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern(buf), 1));
   mem_push_symbol_atom(mem, (LmnSymbolAtomRef)a);
   lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), a, LMN_ATTR_MAKE_LINK(0),
                   0);
@@ -692,7 +692,7 @@ void cb_port_output_string(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
     lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), s, LMN_STRING_ATTR, 0);
   } else {
     LmnSAtom a = lmn_mem_newatom(
-        mem, lmn_functor_intern(ANONYMOUS, lmn_intern("error"), 1));
+        mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("error"), 1));
     lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), a,
                     LMN_ATTR_MAKE_LINK(0), 0);
   }
@@ -722,7 +722,7 @@ void sp_cb_port_dump(void *data, LmnPortRef port) {
 BOOL sp_cp_port_is_ground(void *data) { return FALSE; }
 
 void port_init() {
-  eof_functor = lmn_functor_intern(ANONYMOUS, lmn_intern("eof"), 1);
+  eof_functor = lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("eof"), 1);
 
   port_atom_type = lmn_sp_atom_register("port", sp_cb_port_copy,
                                         sp_cb_port_free, sp_cb_port_eq,

--- a/src/ext/atom.cpp
+++ b/src/ext/atom.cpp
@@ -46,7 +46,7 @@
 static LmnSymbolAtomRef lmn_make_atom(LmnMembraneRef mem, LmnAtomRef s, LmnWord size)
 {
   LmnSymbolAtomRef a = lmn_mem_newatom(mem,
-         lmn_functor_table.lmn_functor_intern(ANONYMOUS, 
+         lmn_functor_table.intern(ANONYMOUS,
 			    lmn_intern(reinterpret_cast<LmnString *>(s)->c_str()),
 			    size));
   for (LmnWord k = 0; k < (int)size-1; k++) {
@@ -81,7 +81,7 @@ void cb_atom_new(LmnReactCxtRef rc,
   LmnWord a1 = (LmnWord)a1_; /**< a1 is assumed to be an integer data atom */
   if (a1 > 0 && a1 <= 127) {
     atom = lmn_make_atom(mem, a0, a1);
-    res = lmn_mem_newatom(mem,lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("some"), 2));
+    res = lmn_mem_newatom(mem,lmn_functor_table.intern(ANONYMOUS, lmn_intern("some"), 2));
     lmn_mem_newlink(mem,
 		    atom, LMN_ATTR_MAKE_LINK(0), a1-1,
 		    res, LMN_ATTR_MAKE_LINK(0), 0);
@@ -92,7 +92,7 @@ void cb_atom_new(LmnReactCxtRef rc,
     lmn_mem_delete_atom(mem, a0, t0);
   } else if (a1 == 0) {
     atom = lmn_make_atom(mem, a0, a1);
-    res = lmn_mem_newatom(mem,lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("nullary"), 1));
+    res = lmn_mem_newatom(mem,lmn_functor_table.intern(ANONYMOUS, lmn_intern("nullary"), 1));
     lmn_mem_newlink(mem,
       a2, t2, LMN_ATTR_GET_VALUE(t2),
       res, LMN_ATTR_MAKE_LINK(0), 0);

--- a/src/ext/atom.cpp
+++ b/src/ext/atom.cpp
@@ -164,7 +164,7 @@ void cb_atom_swap(LmnReactCxtRef rc,
   if (LMN_ATTR_IS_DATA(t3)) 
     lmn_fatal("Arg 3 of atom.swap cannot be non-symbol atoms (numbers, strings, ...).");
 
-  if ((unsigned long)a1 >= LMN_FUNCTOR_ARITY(((LmnSymbolAtomRef)a0)->get_functor()))
+  if ((unsigned long)a1 >= LMN_FUNCTOR_ARITY(lmn_functor_table, ((LmnSymbolAtomRef)a0)->get_functor()))
     lmn_fatal("atom.swap index out of range.");
 
   self  = ((LmnSymbolAtomRef)a0)->get_link(t0);

--- a/src/ext/atom.cpp
+++ b/src/ext/atom.cpp
@@ -46,7 +46,7 @@
 static LmnSymbolAtomRef lmn_make_atom(LmnMembraneRef mem, LmnAtomRef s, LmnWord size)
 {
   LmnSymbolAtomRef a = lmn_mem_newatom(mem,
-         lmn_functor_table.intern(ANONYMOUS,
+         lmn_functor_table->intern(ANONYMOUS,
 			    lmn_intern(reinterpret_cast<LmnString *>(s)->c_str()),
 			    size));
   for (LmnWord k = 0; k < (int)size-1; k++) {
@@ -81,7 +81,7 @@ void cb_atom_new(LmnReactCxtRef rc,
   LmnWord a1 = (LmnWord)a1_; /**< a1 is assumed to be an integer data atom */
   if (a1 > 0 && a1 <= 127) {
     atom = lmn_make_atom(mem, a0, a1);
-    res = lmn_mem_newatom(mem,lmn_functor_table.intern(ANONYMOUS, lmn_intern("some"), 2));
+    res = lmn_mem_newatom(mem,lmn_functor_table->intern(ANONYMOUS, lmn_intern("some"), 2));
     lmn_mem_newlink(mem,
 		    atom, LMN_ATTR_MAKE_LINK(0), a1-1,
 		    res, LMN_ATTR_MAKE_LINK(0), 0);
@@ -92,7 +92,7 @@ void cb_atom_new(LmnReactCxtRef rc,
     lmn_mem_delete_atom(mem, a0, t0);
   } else if (a1 == 0) {
     atom = lmn_make_atom(mem, a0, a1);
-    res = lmn_mem_newatom(mem,lmn_functor_table.intern(ANONYMOUS, lmn_intern("nullary"), 1));
+    res = lmn_mem_newatom(mem,lmn_functor_table->intern(ANONYMOUS, lmn_intern("nullary"), 1));
     lmn_mem_newlink(mem,
       a2, t2, LMN_ATTR_GET_VALUE(t2),
       res, LMN_ATTR_MAKE_LINK(0), 0);

--- a/src/ext/atom.cpp
+++ b/src/ext/atom.cpp
@@ -46,7 +46,7 @@
 static LmnSymbolAtomRef lmn_make_atom(LmnMembraneRef mem, LmnAtomRef s, LmnWord size)
 {
   LmnSymbolAtomRef a = lmn_mem_newatom(mem,
-         lmn_functor_intern(ANONYMOUS, 
+         lmn_functor_table.lmn_functor_intern(ANONYMOUS, 
 			    lmn_intern(reinterpret_cast<LmnString *>(s)->c_str()),
 			    size));
   for (LmnWord k = 0; k < (int)size-1; k++) {
@@ -81,7 +81,7 @@ void cb_atom_new(LmnReactCxtRef rc,
   LmnWord a1 = (LmnWord)a1_; /**< a1 is assumed to be an integer data atom */
   if (a1 > 0 && a1 <= 127) {
     atom = lmn_make_atom(mem, a0, a1);
-    res = lmn_mem_newatom(mem,lmn_functor_intern(ANONYMOUS, lmn_intern("some"), 2));
+    res = lmn_mem_newatom(mem,lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("some"), 2));
     lmn_mem_newlink(mem,
 		    atom, LMN_ATTR_MAKE_LINK(0), a1-1,
 		    res, LMN_ATTR_MAKE_LINK(0), 0);
@@ -92,7 +92,7 @@ void cb_atom_new(LmnReactCxtRef rc,
     lmn_mem_delete_atom(mem, a0, t0);
   } else if (a1 == 0) {
     atom = lmn_make_atom(mem, a0, a1);
-    res = lmn_mem_newatom(mem,lmn_functor_intern(ANONYMOUS, lmn_intern("nullary"), 1));
+    res = lmn_mem_newatom(mem,lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("nullary"), 1));
     lmn_mem_newlink(mem,
       a2, t2, LMN_ATTR_GET_VALUE(t2),
       res, LMN_ATTR_MAKE_LINK(0), 0);

--- a/src/ext/float.cpp
+++ b/src/ext/float.cpp
@@ -60,7 +60,7 @@ void float_of_string(LmnReactCxtRef rc,
   t = NULL;
   d = (LmnAtomRef)lmn_create_double_atom(strtod(s, &t));
   if (t == NULL || s == t) {
-    LmnSAtom a = lmn_mem_newatom(mem, lmn_functor_intern(ANONYMOUS,
+    LmnSAtom a = lmn_mem_newatom(mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS,
                                                          lmn_intern("fail"),
                                                          1));
     lmn_mem_newlink(mem,

--- a/src/ext/float.cpp
+++ b/src/ext/float.cpp
@@ -60,7 +60,7 @@ void float_of_string(LmnReactCxtRef rc,
   t = NULL;
   d = (LmnAtomRef)lmn_create_double_atom(strtod(s, &t));
   if (t == NULL || s == t) {
-    LmnSAtom a = lmn_mem_newatom(mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS,
+    LmnSAtom a = lmn_mem_newatom(mem, lmn_functor_table.intern(ANONYMOUS,
                                                          lmn_intern("fail"),
                                                          1));
     lmn_mem_newlink(mem,

--- a/src/ext/float.cpp
+++ b/src/ext/float.cpp
@@ -60,7 +60,7 @@ void float_of_string(LmnReactCxtRef rc,
   t = NULL;
   d = (LmnAtomRef)lmn_create_double_atom(strtod(s, &t));
   if (t == NULL || s == t) {
-    LmnSAtom a = lmn_mem_newatom(mem, lmn_functor_table.intern(ANONYMOUS,
+    LmnSAtom a = lmn_mem_newatom(mem, lmn_functor_table->intern(ANONYMOUS,
                                                          lmn_intern("fail"),
                                                          1));
     lmn_mem_newlink(mem,

--- a/src/ext/integer.cpp
+++ b/src/ext/integer.cpp
@@ -163,7 +163,7 @@ void integer_of_string(LmnReactCxtRef rc,
   t = NULL;
   n = strtol(s, &t, 10);
   if (t == NULL || s == t) {
-    LmnSymbolAtomRef a = lmn_mem_newatom(mem, lmn_functor_intern(ANONYMOUS,
+    LmnSymbolAtomRef a = lmn_mem_newatom(mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS,
                                                          lmn_intern("fail"),
                                                          1));
     lmn_mem_newlink(mem,

--- a/src/ext/integer.cpp
+++ b/src/ext/integer.cpp
@@ -163,7 +163,7 @@ void integer_of_string(LmnReactCxtRef rc,
   t = NULL;
   n = strtol(s, &t, 10);
   if (t == NULL || s == t) {
-    LmnSymbolAtomRef a = lmn_mem_newatom(mem, lmn_functor_table.intern(ANONYMOUS,
+    LmnSymbolAtomRef a = lmn_mem_newatom(mem, lmn_functor_table->intern(ANONYMOUS,
                                                          lmn_intern("fail"),
                                                          1));
     lmn_mem_newlink(mem,

--- a/src/ext/integer.cpp
+++ b/src/ext/integer.cpp
@@ -163,7 +163,7 @@ void integer_of_string(LmnReactCxtRef rc,
   t = NULL;
   n = strtol(s, &t, 10);
   if (t == NULL || s == t) {
-    LmnSymbolAtomRef a = lmn_mem_newatom(mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS,
+    LmnSymbolAtomRef a = lmn_mem_newatom(mem, lmn_functor_table.intern(ANONYMOUS,
                                                          lmn_intern("fail"),
                                                          1));
     lmn_mem_newlink(mem,

--- a/src/ext/io.cpp
+++ b/src/ext/io.cpp
@@ -112,7 +112,7 @@ void cb_print_line_with_port(LmnReactCxtRef rc,
 //   }
 // 
 //   if (ferror(stdin)) {/* error */
-//    LmnSAtom atom = lmn_new_atom(lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("error"), 1));
+//    LmnSAtom atom = lmn_new_atom(lmn_functor_table.intern(ANONYMOUS, lmn_intern("error"), 1));
 //     lmn_mem_newlink(mem,
 //                     a0, t0, LMN_ATTR_GET_VALUE(t0),
 //                     LMN_ATOM(atom), LMN_ATTR_MAKE_LINK(0), 0);
@@ -120,7 +120,7 @@ void cb_print_line_with_port(LmnReactCxtRef rc,
 //     if (s) LMN_FREE(s);
 //   }
 //   else if (feof(stdin) && s == NULL) { /* eof */
-//     LmnSAtom atom = lmn_new_atom(lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("eof"), 1));
+//     LmnSAtom atom = lmn_new_atom(lmn_functor_table.intern(ANONYMOUS, lmn_intern("eof"), 1));
 //     lmn_mem_newlink(mem,
 //                     a0, t0, LMN_ATTR_GET_VALUE(t0),
 //                     LMN_ATOM(atom), LMN_ATTR_MAKE_LINK(0), 0);

--- a/src/ext/io.cpp
+++ b/src/ext/io.cpp
@@ -112,7 +112,7 @@ void cb_print_line_with_port(LmnReactCxtRef rc,
 //   }
 // 
 //   if (ferror(stdin)) {/* error */
-//    LmnSAtom atom = lmn_new_atom(lmn_functor_intern(ANONYMOUS, lmn_intern("error"), 1));
+//    LmnSAtom atom = lmn_new_atom(lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("error"), 1));
 //     lmn_mem_newlink(mem,
 //                     a0, t0, LMN_ATTR_GET_VALUE(t0),
 //                     LMN_ATOM(atom), LMN_ATTR_MAKE_LINK(0), 0);
@@ -120,7 +120,7 @@ void cb_print_line_with_port(LmnReactCxtRef rc,
 //     if (s) LMN_FREE(s);
 //   }
 //   else if (feof(stdin) && s == NULL) { /* eof */
-//     LmnSAtom atom = lmn_new_atom(lmn_functor_intern(ANONYMOUS, lmn_intern("eof"), 1));
+//     LmnSAtom atom = lmn_new_atom(lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("eof"), 1));
 //     lmn_mem_newlink(mem,
 //                     a0, t0, LMN_ATTR_GET_VALUE(t0),
 //                     LMN_ATOM(atom), LMN_ATTR_MAKE_LINK(0), 0);

--- a/src/ext/nd_conf.cpp
+++ b/src/ext/nd_conf.cpp
@@ -57,7 +57,7 @@ void cb_set_functor_priority(LmnReactCxtRef rc,
                              LmnAtomRef a1, LmnLinkAttr t1,
                              LmnAtomRef a2, LmnLinkAttr t2)
 {
-  set_functor_priority(lmn_functor_intern(ANONYMOUS,
+  set_functor_priority(lmn_functor_table.lmn_functor_intern(ANONYMOUS,
                                           LMN_FUNCTOR_NAME_ID(((LmnSymbolAtomRef)a1)->get_functor()),
                                           (LmnWord)a2),
                        (LmnWord)a0);

--- a/src/ext/nd_conf.cpp
+++ b/src/ext/nd_conf.cpp
@@ -57,7 +57,7 @@ void cb_set_functor_priority(LmnReactCxtRef rc,
                              LmnAtomRef a1, LmnLinkAttr t1,
                              LmnAtomRef a2, LmnLinkAttr t2)
 {
-  set_functor_priority(lmn_functor_table.lmn_functor_intern(ANONYMOUS,
+  set_functor_priority(lmn_functor_table.intern(ANONYMOUS,
                                           LMN_FUNCTOR_NAME_ID(((LmnSymbolAtomRef)a1)->get_functor()),
                                           (LmnWord)a2),
                        (LmnWord)a0);

--- a/src/ext/nd_conf.cpp
+++ b/src/ext/nd_conf.cpp
@@ -57,7 +57,7 @@ void cb_set_functor_priority(LmnReactCxtRef rc,
                              LmnAtomRef a1, LmnLinkAttr t1,
                              LmnAtomRef a2, LmnLinkAttr t2)
 {
-  set_functor_priority(lmn_functor_table.intern(ANONYMOUS,
+  set_functor_priority(lmn_functor_table->intern(ANONYMOUS,
                                           LMN_FUNCTOR_NAME_ID(((LmnSymbolAtomRef)a1)->get_functor()),
                                           (LmnWord)a2),
                        (LmnWord)a0);

--- a/src/ext/nd_conf.cpp
+++ b/src/ext/nd_conf.cpp
@@ -58,8 +58,8 @@ void cb_set_functor_priority(LmnReactCxtRef rc,
                              LmnAtomRef a2, LmnLinkAttr t2)
 {
   set_functor_priority(lmn_functor_table->intern(ANONYMOUS,
-                                          LMN_FUNCTOR_NAME_ID(((LmnSymbolAtomRef)a1)->get_functor()),
-                                          (LmnWord)a2),
+                             LMN_FUNCTOR_NAME_ID(lmn_functor_table, ((LmnSymbolAtomRef)a1)->get_functor()),
+                             (LmnWord)a2),
                        (LmnWord)a0);
   lmn_mem_delete_atom(mem, a0, t0);
   lmn_mem_delete_atom(mem, a1, t1);

--- a/src/ext/nlmem.cpp
+++ b/src/ext/nlmem.cpp
@@ -51,7 +51,7 @@ void nlmem_copy(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
   LmnFunctor copy_tag_func;
 
   copy_tag_name = LMN_FUNCTOR_NAME_ID(((LmnSymbolAtomRef)a1)->get_functor());
-  copy_tag_func = lmn_functor_table.intern(ANONYMOUS, copy_tag_name, 3);
+  copy_tag_func = lmn_functor_table->intern(ANONYMOUS, copy_tag_name, 3);
   org_mem = LMN_PROXY_GET_MEM((LmnSymbolAtomRef)((LmnSymbolAtomRef)a0)->get_link(0));
   trg_mem = lmn_mem_make();
   atom_map = lmn_mem_copy_cells(trg_mem, org_mem);

--- a/src/ext/nlmem.cpp
+++ b/src/ext/nlmem.cpp
@@ -51,7 +51,7 @@ void nlmem_copy(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
   LmnFunctor copy_tag_func;
 
   copy_tag_name = LMN_FUNCTOR_NAME_ID(((LmnSymbolAtomRef)a1)->get_functor());
-  copy_tag_func = lmn_functor_intern(ANONYMOUS, copy_tag_name, 3);
+  copy_tag_func = lmn_functor_table.lmn_functor_intern(ANONYMOUS, copy_tag_name, 3);
   org_mem = LMN_PROXY_GET_MEM((LmnSymbolAtomRef)((LmnSymbolAtomRef)a0)->get_link(0));
   trg_mem = lmn_mem_make();
   atom_map = lmn_mem_copy_cells(trg_mem, org_mem);

--- a/src/ext/nlmem.cpp
+++ b/src/ext/nlmem.cpp
@@ -51,7 +51,7 @@ void nlmem_copy(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
   LmnFunctor copy_tag_func;
 
   copy_tag_name = LMN_FUNCTOR_NAME_ID(((LmnSymbolAtomRef)a1)->get_functor());
-  copy_tag_func = lmn_functor_table.lmn_functor_intern(ANONYMOUS, copy_tag_name, 3);
+  copy_tag_func = lmn_functor_table.intern(ANONYMOUS, copy_tag_name, 3);
   org_mem = LMN_PROXY_GET_MEM((LmnSymbolAtomRef)((LmnSymbolAtomRef)a0)->get_link(0));
   trg_mem = lmn_mem_make();
   atom_map = lmn_mem_copy_cells(trg_mem, org_mem);

--- a/src/ext/nlmem.cpp
+++ b/src/ext/nlmem.cpp
@@ -50,7 +50,7 @@ void nlmem_copy(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
   lmn_interned_str copy_tag_name;
   LmnFunctor copy_tag_func;
 
-  copy_tag_name = LMN_FUNCTOR_NAME_ID(((LmnSymbolAtomRef)a1)->get_functor());
+  copy_tag_name = LMN_FUNCTOR_NAME_ID(lmn_functor_table, ((LmnSymbolAtomRef)a1)->get_functor());
   copy_tag_func = lmn_functor_table->intern(ANONYMOUS, copy_tag_name, 3);
   org_mem = LMN_PROXY_GET_MEM((LmnSymbolAtomRef)((LmnSymbolAtomRef)a0)->get_link(0));
   trg_mem = lmn_mem_make();

--- a/src/ext/react_rule.cpp
+++ b/src/ext/react_rule.cpp
@@ -55,7 +55,7 @@ void cb_react_rule(LmnReactCxtRef rc,
 
   int reacted = react_rule(&tmp_rc, graph_mem, r);
   lmn_interned_str str = (reacted) ? lmn_intern("success") : lmn_intern("fail");
-  LmnSymbolAtomRef result = lmn_mem_newatom(mem, lmn_functor_table.intern(ANONYMOUS, str, 2));
+  LmnSymbolAtomRef result = lmn_mem_newatom(mem, lmn_functor_table->intern(ANONYMOUS, str, 2));
 
   lmn_mem_newlink(mem,
                   result, LMN_ATTR_MAKE_LINK(0), 0,

--- a/src/ext/react_rule.cpp
+++ b/src/ext/react_rule.cpp
@@ -55,7 +55,7 @@ void cb_react_rule(LmnReactCxtRef rc,
 
   int reacted = react_rule(&tmp_rc, graph_mem, r);
   lmn_interned_str str = (reacted) ? lmn_intern("success") : lmn_intern("fail");
-  LmnSymbolAtomRef result = lmn_mem_newatom(mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS, str, 2));
+  LmnSymbolAtomRef result = lmn_mem_newatom(mem, lmn_functor_table.intern(ANONYMOUS, str, 2));
 
   lmn_mem_newlink(mem,
                   result, LMN_ATTR_MAKE_LINK(0), 0,

--- a/src/ext/react_rule.cpp
+++ b/src/ext/react_rule.cpp
@@ -55,7 +55,7 @@ void cb_react_rule(LmnReactCxtRef rc,
 
   int reacted = react_rule(&tmp_rc, graph_mem, r);
   lmn_interned_str str = (reacted) ? lmn_intern("success") : lmn_intern("fail");
-  LmnSymbolAtomRef result = lmn_mem_newatom(mem, lmn_functor_intern(ANONYMOUS, str, 2));
+  LmnSymbolAtomRef result = lmn_mem_newatom(mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS, str, 2));
 
   lmn_mem_newlink(mem,
                   result, LMN_ATTR_MAKE_LINK(0), 0,

--- a/src/ext/set.cpp
+++ b/src/ext/set.cpp
@@ -117,7 +117,7 @@ LmnBinStrRef lmn_inner_mem_encode(LmnMembraneRef m) {
   lmn_delete_atom((LmnSymbolAtomRef)in);
 
   LmnAtomRef at =
-      lmn_mem_newatom(m, lmn_functor_table.intern(ANONYMOUS, lmn_intern("@"), 1));
+      lmn_mem_newatom(m, lmn_functor_table->intern(ANONYMOUS, lmn_intern("@"), 1));
   lmn_newlink_in_symbols((LmnSymbolAtomRef)plus, 0, (LmnSymbolAtomRef)at, 0);
 
   LmnBinStrRef s = lmn_mem_encode(m);
@@ -298,7 +298,7 @@ void cb_set_find(LmnReactCxtRef *rc, LmnMembraneRef mem, LmnAtomRef a0,
   st_data_t entry;
   int res = st_lookup(tbl, (st_data_t)key, &entry);
   lmn_interned_str s = (res) ? lmn_intern("some") : lmn_intern("none");
-  LmnAtomRef result = lmn_mem_newatom(mem, lmn_functor_table.intern(ANONYMOUS, s, 1));
+  LmnAtomRef result = lmn_mem_newatom(mem, lmn_functor_table->intern(ANONYMOUS, s, 1));
   lmn_mem_newlink(mem, a0, t0, LMN_ATTR_GET_VALUE(t0), a3, t3,
                   LMN_ATTR_GET_VALUE(t3));
   lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), result,
@@ -533,7 +533,7 @@ void cb_set_intersect(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
                     LMN_ATTR_GET_VALUE(t0));
   } else {
     LmnAtomRef empty_set = lmn_mem_newatom(
-        mem, lmn_functor_table.intern(ANONYMOUS, lmn_intern("set_empty"), 1));
+        mem, lmn_functor_table->intern(ANONYMOUS, lmn_intern("set_empty"), 1));
     lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), empty_set,
                     LMN_ATTR_MAKE_LINK(0), 0);
     lmn_set_free((LmnSetRef)a0);
@@ -581,7 +581,7 @@ void cb_set_diff(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
                     LMN_ATTR_GET_VALUE(t0));
   } else {
     LmnAtomRef empty_set = lmn_mem_newatom(
-        mem, lmn_functor_table.intern(ANONYMOUS, lmn_intern("set_empty"), 1));
+        mem, lmn_functor_table->intern(ANONYMOUS, lmn_intern("set_empty"), 1));
     lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), (LmnAtomRef)empty_set,
                     LMN_ATTR_MAKE_LINK(0), 0);
     lmn_set_free((LmnSetRef)a0);

--- a/src/ext/set.cpp
+++ b/src/ext/set.cpp
@@ -117,7 +117,7 @@ LmnBinStrRef lmn_inner_mem_encode(LmnMembraneRef m) {
   lmn_delete_atom((LmnSymbolAtomRef)in);
 
   LmnAtomRef at =
-      lmn_mem_newatom(m, lmn_functor_intern(ANONYMOUS, lmn_intern("@"), 1));
+      lmn_mem_newatom(m, lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("@"), 1));
   lmn_newlink_in_symbols((LmnSymbolAtomRef)plus, 0, (LmnSymbolAtomRef)at, 0);
 
   LmnBinStrRef s = lmn_mem_encode(m);
@@ -298,7 +298,7 @@ void cb_set_find(LmnReactCxtRef *rc, LmnMembraneRef mem, LmnAtomRef a0,
   st_data_t entry;
   int res = st_lookup(tbl, (st_data_t)key, &entry);
   lmn_interned_str s = (res) ? lmn_intern("some") : lmn_intern("none");
-  LmnAtomRef result = lmn_mem_newatom(mem, lmn_functor_intern(ANONYMOUS, s, 1));
+  LmnAtomRef result = lmn_mem_newatom(mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS, s, 1));
   lmn_mem_newlink(mem, a0, t0, LMN_ATTR_GET_VALUE(t0), a3, t3,
                   LMN_ATTR_GET_VALUE(t3));
   lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), result,
@@ -533,7 +533,7 @@ void cb_set_intersect(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
                     LMN_ATTR_GET_VALUE(t0));
   } else {
     LmnAtomRef empty_set = lmn_mem_newatom(
-        mem, lmn_functor_intern(ANONYMOUS, lmn_intern("set_empty"), 1));
+        mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("set_empty"), 1));
     lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), empty_set,
                     LMN_ATTR_MAKE_LINK(0), 0);
     lmn_set_free((LmnSetRef)a0);
@@ -581,7 +581,7 @@ void cb_set_diff(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
                     LMN_ATTR_GET_VALUE(t0));
   } else {
     LmnAtomRef empty_set = lmn_mem_newatom(
-        mem, lmn_functor_intern(ANONYMOUS, lmn_intern("set_empty"), 1));
+        mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("set_empty"), 1));
     lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), (LmnAtomRef)empty_set,
                     LMN_ATTR_MAKE_LINK(0), 0);
     lmn_set_free((LmnSetRef)a0);

--- a/src/ext/set.cpp
+++ b/src/ext/set.cpp
@@ -117,7 +117,7 @@ LmnBinStrRef lmn_inner_mem_encode(LmnMembraneRef m) {
   lmn_delete_atom((LmnSymbolAtomRef)in);
 
   LmnAtomRef at =
-      lmn_mem_newatom(m, lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("@"), 1));
+      lmn_mem_newatom(m, lmn_functor_table.intern(ANONYMOUS, lmn_intern("@"), 1));
   lmn_newlink_in_symbols((LmnSymbolAtomRef)plus, 0, (LmnSymbolAtomRef)at, 0);
 
   LmnBinStrRef s = lmn_mem_encode(m);
@@ -298,7 +298,7 @@ void cb_set_find(LmnReactCxtRef *rc, LmnMembraneRef mem, LmnAtomRef a0,
   st_data_t entry;
   int res = st_lookup(tbl, (st_data_t)key, &entry);
   lmn_interned_str s = (res) ? lmn_intern("some") : lmn_intern("none");
-  LmnAtomRef result = lmn_mem_newatom(mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS, s, 1));
+  LmnAtomRef result = lmn_mem_newatom(mem, lmn_functor_table.intern(ANONYMOUS, s, 1));
   lmn_mem_newlink(mem, a0, t0, LMN_ATTR_GET_VALUE(t0), a3, t3,
                   LMN_ATTR_GET_VALUE(t3));
   lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), result,
@@ -533,7 +533,7 @@ void cb_set_intersect(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
                     LMN_ATTR_GET_VALUE(t0));
   } else {
     LmnAtomRef empty_set = lmn_mem_newatom(
-        mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("set_empty"), 1));
+        mem, lmn_functor_table.intern(ANONYMOUS, lmn_intern("set_empty"), 1));
     lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), empty_set,
                     LMN_ATTR_MAKE_LINK(0), 0);
     lmn_set_free((LmnSetRef)a0);
@@ -581,7 +581,7 @@ void cb_set_diff(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
                     LMN_ATTR_GET_VALUE(t0));
   } else {
     LmnAtomRef empty_set = lmn_mem_newatom(
-        mem, lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("set_empty"), 1));
+        mem, lmn_functor_table.intern(ANONYMOUS, lmn_intern("set_empty"), 1));
     lmn_mem_newlink(mem, a2, t2, LMN_ATTR_GET_VALUE(t2), (LmnAtomRef)empty_set,
                     LMN_ATTR_MAKE_LINK(0), 0);
     lmn_set_free((LmnSetRef)a0);

--- a/src/ext/state_map.cpp
+++ b/src/ext/state_map.cpp
@@ -103,7 +103,7 @@ void cb_state_map_id_find(LmnReactCxtRef rc,
   LmnSymbolAtomRef in = (LmnSymbolAtomRef)((LmnSymbolAtomRef)a1)->get_link(0);
   LmnLinkAttr in_attr = ((LmnSymbolAtomRef)a1)->get_attr(0);
 
-  LmnSymbolAtomRef at = lmn_mem_newatom(m, lmn_functor_table.intern(ANONYMOUS, lmn_intern("@"), 1));
+  LmnSymbolAtomRef at = lmn_mem_newatom(m, lmn_functor_table->intern(ANONYMOUS, lmn_intern("@"), 1));
   LmnSymbolAtomRef plus = (LmnSymbolAtomRef)in->get_link(1);
   lmn_newlink_in_symbols(plus, 0, at, 0);
 
@@ -144,7 +144,7 @@ void cb_state_map_state_find(LmnReactCxtRef rc, LmnMembraneRef mem,
   st_data_t entry;
 
   LmnMembraneRef new_mem = s->duplicate_membrane();
-  LmnFunctor at_functor = lmn_functor_table.intern(ANONYMOUS, lmn_intern("@"), 1);
+  LmnFunctor at_functor = lmn_functor_table->intern(ANONYMOUS, lmn_intern("@"), 1);
 
   AtomListEntryRef ent;
   LmnFunctor f;

--- a/src/ext/state_map.cpp
+++ b/src/ext/state_map.cpp
@@ -103,7 +103,7 @@ void cb_state_map_id_find(LmnReactCxtRef rc,
   LmnSymbolAtomRef in = (LmnSymbolAtomRef)((LmnSymbolAtomRef)a1)->get_link(0);
   LmnLinkAttr in_attr = ((LmnSymbolAtomRef)a1)->get_attr(0);
 
-  LmnSymbolAtomRef at = lmn_mem_newatom(m, lmn_functor_intern(ANONYMOUS, lmn_intern("@"), 1));
+  LmnSymbolAtomRef at = lmn_mem_newatom(m, lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("@"), 1));
   LmnSymbolAtomRef plus = (LmnSymbolAtomRef)in->get_link(1);
   lmn_newlink_in_symbols(plus, 0, at, 0);
 
@@ -144,7 +144,7 @@ void cb_state_map_state_find(LmnReactCxtRef rc, LmnMembraneRef mem,
   st_data_t entry;
 
   LmnMembraneRef new_mem = s->duplicate_membrane();
-  LmnFunctor at_functor = lmn_functor_intern(ANONYMOUS, lmn_intern("@"), 1);
+  LmnFunctor at_functor = lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("@"), 1);
 
   AtomListEntryRef ent;
   LmnFunctor f;

--- a/src/ext/state_map.cpp
+++ b/src/ext/state_map.cpp
@@ -103,7 +103,7 @@ void cb_state_map_id_find(LmnReactCxtRef rc,
   LmnSymbolAtomRef in = (LmnSymbolAtomRef)((LmnSymbolAtomRef)a1)->get_link(0);
   LmnLinkAttr in_attr = ((LmnSymbolAtomRef)a1)->get_attr(0);
 
-  LmnSymbolAtomRef at = lmn_mem_newatom(m, lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("@"), 1));
+  LmnSymbolAtomRef at = lmn_mem_newatom(m, lmn_functor_table.intern(ANONYMOUS, lmn_intern("@"), 1));
   LmnSymbolAtomRef plus = (LmnSymbolAtomRef)in->get_link(1);
   lmn_newlink_in_symbols(plus, 0, at, 0);
 
@@ -144,7 +144,7 @@ void cb_state_map_state_find(LmnReactCxtRef rc, LmnMembraneRef mem,
   st_data_t entry;
 
   LmnMembraneRef new_mem = s->duplicate_membrane();
-  LmnFunctor at_functor = lmn_functor_table.lmn_functor_intern(ANONYMOUS, lmn_intern("@"), 1);
+  LmnFunctor at_functor = lmn_functor_table.intern(ANONYMOUS, lmn_intern("@"), 1);
 
   AtomListEntryRef ent;
   LmnFunctor f;

--- a/src/loader/load.cpp
+++ b/src/loader/load.cpp
@@ -175,7 +175,7 @@ LmnRuleSetRef load_and_setting_trans_maindata(struct trans_maindata *maindata) {
     } else {
       /* シンボルは変換を忘れないように */
       LmnFunctor gid =
-          lmn_functor_table.intern(maindata->symbol_exchange[ent.module],
+          lmn_functor_table->intern(maindata->symbol_exchange[ent.module],
                              maindata->symbol_exchange[ent.name], ent.arity);
       maindata->functor_exchange[i] = gid;
     }

--- a/src/loader/load.cpp
+++ b/src/loader/load.cpp
@@ -175,7 +175,7 @@ LmnRuleSetRef load_and_setting_trans_maindata(struct trans_maindata *maindata) {
     } else {
       /* シンボルは変換を忘れないように */
       LmnFunctor gid =
-          lmn_functor_intern(maindata->symbol_exchange[ent.module],
+          lmn_functor_table.lmn_functor_intern(maindata->symbol_exchange[ent.module],
                              maindata->symbol_exchange[ent.name], ent.arity);
       maindata->functor_exchange[i] = gid;
     }

--- a/src/loader/load.cpp
+++ b/src/loader/load.cpp
@@ -175,7 +175,7 @@ LmnRuleSetRef load_and_setting_trans_maindata(struct trans_maindata *maindata) {
     } else {
       /* シンボルは変換を忘れないように */
       LmnFunctor gid =
-          lmn_functor_table.lmn_functor_intern(maindata->symbol_exchange[ent.module],
+          lmn_functor_table.intern(maindata->symbol_exchange[ent.module],
                              maindata->symbol_exchange[ent.name], ent.arity);
       maindata->functor_exchange[i] = gid;
     }

--- a/src/loader/syntax.hpp
+++ b/src/loader/syntax.hpp
@@ -72,9 +72,9 @@ struct string {
 struct symbol {
   lmn_interned_str value;
   symbol(lmn_interned_str name, int arity)
-      : value(lmn_functor_intern(ANONYMOUS, name, arity)) {}
+      : value(lmn_functor_table.lmn_functor_intern(ANONYMOUS, name, arity)) {}
   symbol(lmn_interned_str module, lmn_interned_str name, int arity)
-      : value(lmn_functor_intern(module, name, arity)) {}
+      : value(lmn_functor_table.lmn_functor_intern(module, name, arity)) {}
 };
 } // namespace functor
 

--- a/src/loader/syntax.hpp
+++ b/src/loader/syntax.hpp
@@ -72,9 +72,9 @@ struct string {
 struct symbol {
   lmn_interned_str value;
   symbol(lmn_interned_str name, int arity)
-      : value(lmn_functor_table.lmn_functor_intern(ANONYMOUS, name, arity)) {}
+      : value(lmn_functor_table.intern(ANONYMOUS, name, arity)) {}
   symbol(lmn_interned_str module, lmn_interned_str name, int arity)
-      : value(lmn_functor_table.lmn_functor_intern(module, name, arity)) {}
+      : value(lmn_functor_table.intern(module, name, arity)) {}
 };
 } // namespace functor
 

--- a/src/loader/syntax.hpp
+++ b/src/loader/syntax.hpp
@@ -72,9 +72,9 @@ struct string {
 struct symbol {
   lmn_interned_str value;
   symbol(lmn_interned_str name, int arity)
-      : value(lmn_functor_table.intern(ANONYMOUS, name, arity)) {}
+      : value(lmn_functor_table->intern(ANONYMOUS, name, arity)) {}
   symbol(lmn_interned_str module, lmn_interned_str name, int arity)
-      : value(lmn_functor_table.intern(module, name, arity)) {}
+      : value(lmn_functor_table->intern(module, name, arity)) {}
 };
 } // namespace functor
 

--- a/src/loader/translate.cpp
+++ b/src/loader/translate.cpp
@@ -497,7 +497,7 @@ static void print_trans_maindata(const char *filename) {
   /* シンボルの配列 */
   fprintf(OUT, "  trans_%s_maindata_symbols, /*symboltable*/\n", filename);
   /* ファンクタの個数 */
-  fprintf(OUT, "  %d, /*count of functor*/\n", lmn_functor_table.get_next_id());
+  fprintf(OUT, "  %d, /*count of functor*/\n", lmn_functor_table->get_next_id());
   /* ファンクタの配列 */
   fprintf(OUT, "  trans_%s_maindata_functors, /*functortable*/\n", filename);
   /* ルールセットの個数 */
@@ -544,15 +544,15 @@ static void print_trans_symbols(const char *filename) {
 
 static void print_trans_functors(const char *filename) {
   int i;
-  int count = lmn_functor_table.get_next_id();
+  int count = lmn_functor_table->get_next_id();
   /* idは0から, next_idが1なら既に1個登録済み => count==next_id */
 
   fprintf(OUT, "struct LmnFunctorEntry trans_%s_maindata_functors[%d] = {\n",
           filename, count);
   for (i = 0; i < count; ++i) {
-    fprintf(OUT, "  {%d, %d, %d, %d}", lmn_functor_table.get_entry(i)->special,
-            lmn_functor_table.get_entry(i)->module, lmn_functor_table.get_entry(i)->name,
-            lmn_functor_table.get_entry(i)->arity);
+    fprintf(OUT, "  {%d, %d, %d, %d}", lmn_functor_table->get_entry(i)->special,
+            lmn_functor_table->get_entry(i)->module, lmn_functor_table->get_entry(i)->name,
+            lmn_functor_table->get_entry(i)->arity);
     if (i != count - 1)
       fprintf(OUT, ",");
     fprintf(OUT, "\n");

--- a/src/loader/translate.cpp
+++ b/src/loader/translate.cpp
@@ -497,7 +497,7 @@ static void print_trans_maindata(const char *filename) {
   /* シンボルの配列 */
   fprintf(OUT, "  trans_%s_maindata_symbols, /*symboltable*/\n", filename);
   /* ファンクタの個数 */
-  fprintf(OUT, "  %d, /*count of functor*/\n", lmn_functor_table.next_id);
+  fprintf(OUT, "  %d, /*count of functor*/\n", lmn_functor_table.get_next_id());
   /* ファンクタの配列 */
   fprintf(OUT, "  trans_%s_maindata_functors, /*functortable*/\n", filename);
   /* ルールセットの個数 */
@@ -544,15 +544,15 @@ static void print_trans_symbols(const char *filename) {
 
 static void print_trans_functors(const char *filename) {
   int i;
-  int count = lmn_functor_table.next_id;
+  int count = lmn_functor_table.get_next_id();
   /* idは0から, next_idが1なら既に1個登録済み => count==next_id */
 
   fprintf(OUT, "struct LmnFunctorEntry trans_%s_maindata_functors[%d] = {\n",
           filename, count);
   for (i = 0; i < count; ++i) {
-    fprintf(OUT, "  {%d, %d, %d, %d}", lmn_functor_table.entry[i].special,
-            lmn_functor_table.entry[i].module, lmn_functor_table.entry[i].name,
-            lmn_functor_table.entry[i].arity);
+    fprintf(OUT, "  {%d, %d, %d, %d}", lmn_functor_table.get_entry(i)->special,
+            lmn_functor_table.get_entry(i)->module, lmn_functor_table.get_entry(i)->name,
+            lmn_functor_table.get_entry(i)->arity);
     if (i != count - 1)
       fprintf(OUT, ",");
     fprintf(OUT, "\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -604,7 +604,7 @@ static void parse_options(int *optid, int argc, char *argv[]) {
 static void init_internal(void) {
   lmn_profiler_init(lmn_env.core_num);
   sym_tbl_init();
-  lmn_functor_tbl_init();
+  lmn_functor_table.lmn_functor_tbl_init();
   init_rules();
 
   if (!lmn_env.translate) {
@@ -656,7 +656,7 @@ static inline void slim_finalize(void) {
 
   lmn_profiler_finalize();
   destroy_rules();
-  lmn_functor_tbl_destroy();
+  lmn_functor_table.lmn_functor_tbl_destroy();
   sym_tbl_destroy();
 
   lmn_stream_destroy();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -604,7 +604,7 @@ static void parse_options(int *optid, int argc, char *argv[]) {
 static void init_internal(void) {
   lmn_profiler_init(lmn_env.core_num);
   sym_tbl_init();
-  lmn_functor_table.lmn_functor_tbl_init();
+  lmn_functor_table = new LmnFunctorTable();
   init_rules();
 
   if (!lmn_env.translate) {
@@ -656,7 +656,7 @@ static inline void slim_finalize(void) {
 
   lmn_profiler_finalize();
   destroy_rules();
-  lmn_functor_table.lmn_functor_tbl_destroy();
+  delete lmn_functor_table;
   sym_tbl_destroy();
 
   lmn_stream_destroy();

--- a/src/verifier/mem_encode/decoder.cpp
+++ b/src/verifier/mem_encode/decoder.cpp
@@ -302,10 +302,10 @@ int binstr_decoder::decode_atom(LmnMembraneRef mem, LmnSymbolAtomRef from_atom,
   log[(nvisit)].type = BS_LOG_TYPE_ATOM;
   (nvisit)++;
 
-  for (auto i = 0; i < LMN_FUNCTOR_ARITY(f); i++)
+  for (auto i = 0; i < LMN_FUNCTOR_ARITY(lmn_functor_table, f); i++)
     atom->set_link(i, 0);
 
-  for (auto i = 0; i < LMN_FUNCTOR_ARITY(f); i++) {
+  for (auto i = 0; i < LMN_FUNCTOR_ARITY(lmn_functor_table, f); i++) {
     unsigned int tag = scanner.scan_tag();
 
     if (tag == TAG_FROM) {

--- a/src/verifier/mem_encode/dumper.hpp
+++ b/src/verifier/mem_encode/dumper.hpp
@@ -80,8 +80,8 @@ struct dumper {
       case TAG_ATOM_START: {
         LmnFunctor f = scanner.scan_functor();
         log[v_i] = {(LmnWord)f, BS_LOG_TYPE_ATOM};
-        printf("%s/%d_%d ", lmn_id_to_name(LMN_FUNCTOR_NAME_ID(f)),
-               LMN_FUNCTOR_ARITY(f), v_i++);
+        printf("%s/%d_%d ", lmn_id_to_name(LMN_FUNCTOR_NAME_ID(lmn_functor_table, f)),
+               LMN_FUNCTOR_ARITY(lmn_functor_table, f), v_i++);
       } break;
       case TAG_NAMED_MEM_START: /* FALL THROUGH */
       case TAG_MEM_START: {
@@ -114,8 +114,8 @@ struct dumper {
         } break;
         case TAG_ATOM_START: {
           LmnFunctor f = scanner.scan_functor();
-          printf("%s/%d ", lmn_id_to_name(LMN_FUNCTOR_NAME_ID(f)),
-                 LMN_FUNCTOR_ARITY(f));
+          printf("%s/%d ", lmn_id_to_name(LMN_FUNCTOR_NAME_ID(lmn_functor_table, f)),
+                 LMN_FUNCTOR_ARITY(lmn_functor_table, f));
         } break;
         case TAG_INT_DATA:
         case TAG_DBL_DATA:

--- a/src/verifier/mem_encode/equalizer.hpp
+++ b/src/verifier/mem_encode/equalizer.hpp
@@ -309,7 +309,7 @@ private:
     (*i_ref)++;
 
     /* アトムatomの接続先を検査する */
-    for (auto i = 0; i < LMN_FUNCTOR_ARITY(f); i++) {
+    for (auto i = 0; i < LMN_FUNCTOR_ARITY(lmn_functor_table, f); i++) {
       if (!mem_eq_enc_mol(i_bs, mem, satom->get_link(i),
                           satom->get_attr(i), i_ref)) {
         return FALSE;
@@ -779,7 +779,7 @@ template <> struct equalizer<VisitLog> : public equalizer_base {
     ref_log[*i_ref].type = BS_LOG_TYPE_ATOM;
 
     (*i_ref)++;
-    auto arity = LMN_FUNCTOR_ARITY(f);
+    auto arity = LMN_FUNCTOR_ARITY(lmn_functor_table, f);
 
     /* アトムatomの接続先を検査する */
     for (auto i = 0; i < arity; i++) {

--- a/src/vm/atom.cpp
+++ b/src/vm/atom.cpp
@@ -70,7 +70,7 @@ void LmnSymbolAtom::set_functor(LmnFunctor func) {
   this->functor = func;
 }
 int LmnSymbolAtom::get_arity() const{
-  return LMN_FUNCTOR_ARITY(this->get_functor());
+  return LMN_FUNCTOR_ARITY(lmn_functor_table, this->get_functor());
 }
 int LmnSymbolAtom::get_link_num() const{
   return LMN_FUNCTOR_GET_LINK_NUM(this->get_functor());
@@ -98,7 +98,7 @@ BOOL LmnSymbolAtom::is_proxy() const{
 }
 
 const char *LmnSymbolAtom::str() const {
-  return LMN_SYMBOL_STR(LMN_FUNCTOR_NAME_ID(this->get_functor()));
+  return LMN_SYMBOL_STR(LMN_FUNCTOR_NAME_ID(lmn_functor_table, this->get_functor()));
 }
 
 size_t LMN_SATOM_SIZE(int arity) {
@@ -107,7 +107,7 @@ size_t LMN_SATOM_SIZE(int arity) {
 }
 
 int LMN_FUNCTOR_GET_LINK_NUM(LmnFunctor func) {
-  return LMN_FUNCTOR_ARITY(func) - (LMN_IS_PROXY_FUNCTOR(func) ? 1U : 0U);
+  return LMN_FUNCTOR_ARITY(lmn_functor_table, func) - (LMN_IS_PROXY_FUNCTOR(func) ? 1U : 0U);
 }
 
 int LMN_ATTR_WORDS(int arity) {
@@ -152,7 +152,7 @@ BOOL LMN_IS_SYMBOL_FUNCTOR(LmnFunctor FUNC) {
 /////
 
 const char *LMN_FUNCTOR_STR(LmnFunctor F) {
-  return LMN_SYMBOL_STR(LMN_FUNCTOR_NAME_ID(F));
+  return LMN_SYMBOL_STR(LMN_FUNCTOR_NAME_ID(lmn_functor_table, F));
 }
 
 /////
@@ -184,7 +184,7 @@ LmnSymbolAtomRef lmn_copy_satom(LmnSymbolAtomRef atom) {
   f = atom->get_functor();
   newatom = lmn_new_atom(f);
 
-  memcpy((void *)newatom, (void *)atom, LMN_SATOM_SIZE(LMN_FUNCTOR_ARITY(f)));
+  memcpy((void *)newatom, (void *)atom, LMN_SATOM_SIZE(LMN_FUNCTOR_ARITY(lmn_functor_table, f)));
 
   newatom->set_id(0);
   return newatom;
@@ -223,7 +223,7 @@ LmnSymbolAtomRef lmn_copy_satom_with_data(LmnSymbolAtomRef atom,
 
   LMN_ASSERT(newatom != atom);
 
-  memcpy((void *)newatom, (void *)atom, LMN_SATOM_SIZE(LMN_FUNCTOR_ARITY(f)));
+  memcpy((void *)newatom, (void *)atom, LMN_SATOM_SIZE(LMN_FUNCTOR_ARITY(lmn_functor_table, f)));
   /* リンク先のデータアトムをコピーする */
   for (i = 0; i < arity; i++) {
     if (LMN_ATTR_IS_DATA(atom->get_attr(i))) {

--- a/src/vm/dumper.cpp
+++ b/src/vm/dumper.cpp
@@ -156,14 +156,14 @@ static struct AtomRec *get_atomrec(SimpleHashtbl *ht, LmnSymbolAtomRef atom) {
 
 static void dump_atomname(LmnPortRef port, LmnFunctor f) {
   /* dump module name */
-  if (LMN_FUNCTOR_MODULE_ID(f) != ANONYMOUS) {
-    port_put_raw_s(port, lmn_id_to_name(LMN_FUNCTOR_MODULE_ID(f)));
+  if (LMN_FUNCTOR_MODULE_ID(lmn_functor_table, f) != ANONYMOUS) {
+    port_put_raw_s(port, lmn_id_to_name(LMN_FUNCTOR_MODULE_ID(lmn_functor_table, f)));
     port_put_raw_s(port, ".");
   }
 
   /* dump atom name */
   {
-    const char *atom_name = lmn_id_to_name(LMN_FUNCTOR_NAME_ID(f));
+    const char *atom_name = lmn_id_to_name(LMN_FUNCTOR_NAME_ID(lmn_functor_table, f));
 
     if (is_direct_printable(f)) {
       port_put_raw_s(port, atom_name);
@@ -417,7 +417,7 @@ static BOOL dump_symbol_atom(LmnPortRef port, LmnSymbolAtomRef atom,
   struct AtomRec *t;
 
   f = atom->get_functor();
-  arity = LMN_FUNCTOR_ARITY(f);
+  arity = LMN_FUNCTOR_ARITY(lmn_functor_table, f);
   if (LMN_IS_PROXY_FUNCTOR(f))
     arity--;
 
@@ -436,7 +436,7 @@ static BOOL dump_symbol_atom(LmnPortRef port, LmnSymbolAtomRef atom,
 
   if (call_depth == 0 &&
       (f == LMN_UNARY_PLUS_FUNCTOR || f == LMN_UNARY_MINUS_FUNCTOR)) {
-    port_put_raw_s(port, lmn_id_to_name(LMN_FUNCTOR_NAME_ID(f)));
+    port_put_raw_s(port, lmn_id_to_name(LMN_FUNCTOR_NAME_ID(lmn_functor_table, f)));
     return dump_atom(port, atom->get_link(0), ht,
                      atom->get_attr(0), s, 1);
   }
@@ -760,11 +760,11 @@ void dump_atom_dev(LmnSymbolAtomRef atom) {
   unsigned int i;
 
   f = atom->get_functor();
-  arity = LMN_FUNCTOR_ARITY(f);
+  arity = LMN_FUNCTOR_ARITY(lmn_functor_table, f);
 
   esc_code_add(CODE__FORECOLOR_LIGHTBLUE);
   fprintf(stdout, "Func[%3u], Name[%5s], A[%2u], Addr[%p], ID[%2lu], ", f,
-          lmn_id_to_name(LMN_FUNCTOR_NAME_ID(f)), arity, atom,
+          lmn_id_to_name(LMN_FUNCTOR_NAME_ID(lmn_functor_table, f)), arity, atom,
           atom->get_id());
 
   if (LMN_FUNC_IS_HL(f)) {

--- a/src/vm/firstclass_rule.cpp
+++ b/src/vm/firstclass_rule.cpp
@@ -157,7 +157,7 @@ std::string string_of_template_membrane(Vector *link_connections,
         satom, ent, ({
           int arity = LMN_FUNCTOR_GET_LINK_NUM(satom->get_functor());
           const char *atom_name =
-              lmn_id_to_name(LMN_FUNCTOR_NAME_ID(satom->get_functor()));
+              lmn_id_to_name(LMN_FUNCTOR_NAME_ID(lmn_functor_table, satom->get_functor()));
 
           if (f == LMN_UNARY_PLUS_FUNCTOR) {
             LmnSymbolAtomRef in_proxy =
@@ -262,7 +262,7 @@ std::string string_of_template_membrane(Vector *link_connections,
 std::string string_of_guard_op(LmnSymbolAtomRef satom) {
   std::string result;
   const char *atom_name =
-      lmn_id_to_name(LMN_FUNCTOR_NAME_ID(satom->get_functor()));
+      lmn_id_to_name(LMN_FUNCTOR_NAME_ID(lmn_functor_table, satom->get_functor()));
   int arity = LMN_FUNCTOR_GET_LINK_NUM(satom->get_functor());
   LmnLinkAttr attr;
   if (arity == 1)
@@ -310,7 +310,7 @@ std::string string_of_guard_mem(LmnMembraneRef mem, LmnSymbolAtomRef cm_atom) {
     EACH_ATOM(
         satom, ent, ({
           const char *atom_name =
-              lmn_id_to_name(LMN_FUNCTOR_NAME_ID(satom->get_functor()));
+              lmn_id_to_name(LMN_FUNCTOR_NAME_ID(lmn_functor_table, satom->get_functor()));
 
           if (f == LMN_UNARY_PLUS_FUNCTOR) {
             LmnSymbolAtomRef in_proxy =
@@ -326,7 +326,7 @@ std::string string_of_guard_mem(LmnMembraneRef mem, LmnSymbolAtomRef cm_atom) {
               LmnSymbolAtomRef typed_pc_atom =
                   (LmnSymbolAtomRef)satom->get_link(0);
               const char *typed_pc_atom_name = lmn_id_to_name(
-                  LMN_FUNCTOR_NAME_ID(typed_pc_atom->get_functor()));
+                  LMN_FUNCTOR_NAME_ID(lmn_functor_table, typed_pc_atom->get_functor()));
               result += constraint_name[i];
               result += "(";
               result += typed_pc_atom_name;

--- a/src/vm/functor.cpp
+++ b/src/vm/functor.cpp
@@ -218,7 +218,7 @@ LmnFunctor LmnFunctorTable::functor_intern(BOOL special, lmn_interned_str module
   }
 }
 
-LmnFunctor LmnFunctorTable::lmn_functor_intern(lmn_interned_str module, lmn_interned_str name,
+LmnFunctor LmnFunctorTable::intern(lmn_interned_str module, lmn_interned_str name,
                               int arity) {
   return functor_intern(FALSE, module, name, arity);
 }

--- a/src/vm/functor.cpp
+++ b/src/vm/functor.cpp
@@ -83,20 +83,28 @@ struct PredefinedFunctor predefined_functors[] = {
 
 LmnFunctorTable lmn_functor_table;
 
-/* prototypes */
+  LmnFunctorEntry *LmnFunctorTable::get_entry(unsigned int f){
+    return &entry[f];
+  }
 
+  unsigned int LmnFunctorTable::get_size(){
+    return size;
+  }
+
+  unsigned int LmnFunctorTable::get_next_id(){
+    return next_id;
+  }
 /* ファンクタの比較 */
-static int functor_cmp(LmnFunctorEntry *x, LmnFunctorEntry *y) {
+int LmnFunctorTable::functor_cmp(LmnFunctorEntry *x, LmnFunctorEntry *y) {
   return !(x->module == y->module && x->name == y->name &&
            x->arity == y->arity);
 }
-
-static long functor_hash(LmnFunctorEntry *x) {
+long LmnFunctorTable::functor_hash(LmnFunctorEntry *x) {
   return x->module * 31 * 31 + x->name * 31 + x->arity;
 }
 
-static struct st_hash_type type_functorhash = {(st_cmp_func)functor_cmp,
-                                               (st_hash_func)functor_hash};
+static struct st_hash_type type_functorhash = {(st_cmp_func)LmnFunctorTable::functor_cmp,
+                                               (st_hash_func)LmnFunctorTable::functor_hash};
 
 st_table_t
     functor_id_tbl; /* ファンクタ構造体からIDへの対応を要素に持つのテーブル */

--- a/src/vm/functor.cpp
+++ b/src/vm/functor.cpp
@@ -112,7 +112,7 @@ st_table_t
 /* for debug */
 #ifdef DEBUG
 
-void LmnFunctorTable::lmn_functor_tbl_print() {
+void LmnFunctorTable::print() {
   int i, n;
   fprintf(stdout, "next_id==%u\n", next_id);
   n = lmn_functor_table.size;
@@ -122,7 +122,7 @@ void LmnFunctorTable::lmn_functor_tbl_print() {
   }
 }
 
-void LmnFunctorTable::lmn_functor_printer(LmnFunctor f) {
+void LmnFunctorTable::functor_printer(LmnFunctor f) {
   fprintf(stdout, "fid=%d[ %s_%d ]\n", f,
           lmn_id_to_name(LMN_FUNCTOR_NAME_ID(f)), LMN_FUNCTOR_ARITY(f));
 }

--- a/src/vm/functor.cpp
+++ b/src/vm/functor.cpp
@@ -81,7 +81,7 @@ struct PredefinedFunctor predefined_functors[] = {
 #endif
 };
 
-struct LmnFunctorTable lmn_functor_table;
+LmnFunctorTable lmn_functor_table;
 
 /* prototypes */
 
@@ -128,15 +128,15 @@ void lmn_functor_printer(LmnFunctor f) {
 }
 #endif
 
-void lmn_functor_tbl_init() {
+void LmnFunctorTable::lmn_functor_tbl_init() {
   int i;
   const int predefined_size = ARY_SIZEOF(predefined_functors);
 
   functor_id_tbl = st_init_table(&type_functorhash);
 
-  lmn_functor_table.size = predefined_size;
-  lmn_functor_table.entry = LMN_NALLOC(LmnFunctorEntry, lmn_functor_table.size);
-  lmn_functor_table.next_id = predefined_size;
+  size = predefined_size;
+  entry = LMN_NALLOC(LmnFunctorEntry, lmn_functor_table.size);
+  next_id = predefined_size;
 
   /* 予約されたファンクタを順番に登録していく */
   for (i = 0; i < predefined_size; i++) {
@@ -151,10 +151,10 @@ int functor_entry_free(LmnFunctorEntry *e) {
   return ST_DELETE;
 }
 
-void lmn_functor_tbl_destroy() {
+void LmnFunctorTable::lmn_functor_tbl_destroy() {
   st_foreach(functor_id_tbl, (st_iter_func)functor_entry_free, 0);
   st_free_table(functor_id_tbl);
-  LMN_FREE(lmn_functor_table.entry);
+  LMN_FREE(entry);
 }
 
 const LmnFunctorEntry *lmn_id_to_functor(int functor_id) {

--- a/src/vm/functor.cpp
+++ b/src/vm/functor.cpp
@@ -115,13 +115,13 @@ void LmnFunctorTable::print() {
   n = this.size;
   for (i = 0; i < n; i++) {
     fprintf(stdout, "entry[%2d]== %s_%d\n", i,
-            lmn_id_to_name(LMN_FUNCTOR_NAME_ID(i)), LMN_FUNCTOR_ARITY(i));
+            lmn_id_to_name(LMN_FUNCTOR_NAME_ID(lmn_functor_table, i)), LMN_FUNCTOR_ARITY(lmn_functor_table, i));
   }
 }
 
 void LmnFunctorTable::functor_printer(LmnFunctor f) {
   fprintf(stdout, "fid=%d[ %s_%d ]\n", f,
-          lmn_id_to_name(LMN_FUNCTOR_NAME_ID(f)), LMN_FUNCTOR_ARITY(f));
+          lmn_id_to_name(LMN_FUNCTOR_NAME_ID(lmn_functor_table, f)), LMN_FUNCTOR_ARITY(lmn_functor_table, f));
 }
 #endif
 

--- a/src/vm/functor.cpp
+++ b/src/vm/functor.cpp
@@ -85,9 +85,6 @@ LmnFunctorTable lmn_functor_table;
 
 /* prototypes */
 
-int functor_entry_free(LmnFunctorEntry *e);
-const LmnFunctorEntry *lmn_id_to_functor(int functor_id);
-
 /* ファンクタの比較 */
 static int functor_cmp(LmnFunctorEntry *x, LmnFunctorEntry *y) {
   return !(x->module == y->module && x->name == y->name &&
@@ -107,9 +104,9 @@ st_table_t
 /* for debug */
 #ifdef DEBUG
 
-void lmn_functor_tbl_print() {
+void LmnFunctorTable::lmn_functor_tbl_print() {
   int i, n;
-  fprintf(stdout, "next_id==%u\n", lmn_functor_table.next_id);
+  fprintf(stdout, "next_id==%u\n", next_id);
   n = lmn_functor_table.size;
   for (i = 0; i < n; i++) {
     fprintf(stdout, "entry[%2d]== %s_%d\n", i,
@@ -117,7 +114,7 @@ void lmn_functor_tbl_print() {
   }
 }
 
-void lmn_functor_printer(LmnFunctor f) {
+void LmnFunctorTable::lmn_functor_printer(LmnFunctor f) {
   fprintf(stdout, "fid=%d[ %s_%d ]\n", f,
           lmn_id_to_name(LMN_FUNCTOR_NAME_ID(f)), LMN_FUNCTOR_ARITY(f));
 }
@@ -130,7 +127,7 @@ void LmnFunctorTable::lmn_functor_tbl_init() {
   functor_id_tbl = st_init_table(&type_functorhash);
 
   size = predefined_size;
-  entry = LMN_NALLOC(LmnFunctorEntry, lmn_functor_table.size);
+  entry = LMN_NALLOC(LmnFunctorEntry, size);
   next_id = predefined_size;
 
   /* 予約されたファンクタを順番に登録していく */
@@ -141,18 +138,18 @@ void LmnFunctorTable::lmn_functor_tbl_init() {
   }
 }
 
-int functor_entry_free(LmnFunctorEntry *e) {
+int LmnFunctorTable::functor_entry_free(LmnFunctorEntry *e) {
   LMN_FREE(e);
   return ST_DELETE;
 }
 
 void LmnFunctorTable::lmn_functor_tbl_destroy() {
-  st_foreach(functor_id_tbl, (st_iter_func)functor_entry_free, 0);
+  st_foreach(functor_id_tbl, (st_iter_func)&LmnFunctorTable::functor_entry_free, 0);
   st_free_table(functor_id_tbl);
   LMN_FREE(entry);
 }
 
-const LmnFunctorEntry *lmn_id_to_functor(int functor_id) {
+LmnFunctorEntry *LmnFunctorTable::lmn_id_to_functor(int functor_id) const{
   LmnFunctorEntry *entry;
 
   if (st_lookup(functor_id_tbl, (st_data_t)functor_id, (st_data_t *)&entry))

--- a/src/vm/functor.cpp
+++ b/src/vm/functor.cpp
@@ -85,11 +85,6 @@ LmnFunctorTable lmn_functor_table;
 
 /* prototypes */
 
-static LmnFunctor functor_intern(BOOL special, lmn_interned_str module,
-                                 lmn_interned_str name, int arity);
-static void register_functor(int id, BOOL special, lmn_interned_str module,
-                             lmn_interned_str name, int arity);
-
 int functor_entry_free(LmnFunctorEntry *e);
 const LmnFunctorEntry *lmn_id_to_functor(int functor_id);
 
@@ -166,7 +161,7 @@ const LmnFunctorEntry *lmn_id_to_functor(int functor_id) {
     return NULL;
 }
 
-static void register_functor(int id, BOOL special, lmn_interned_str module,
+void LmnFunctorTable::register_functor(int id, BOOL special, lmn_interned_str module,
                              lmn_interned_str name, int arity) {
   struct LmnFunctorEntry *entry = LMN_MALLOC(struct LmnFunctorEntry);
 
@@ -177,11 +172,11 @@ static void register_functor(int id, BOOL special, lmn_interned_str module,
 
   st_insert(functor_id_tbl, (st_data_t)entry, (st_data_t)id);
   /* idの位置にファンクタのデータをコピー */
-  lmn_functor_table.entry[id] = *entry;
+  this->entry[id] = *entry;
 }
 
 /* ファンクタのIDを返す */
-static LmnFunctor functor_intern(BOOL special, lmn_interned_str module,
+LmnFunctor LmnFunctorTable::functor_intern(BOOL special, lmn_interned_str module,
                                  lmn_interned_str name, int arity) {
   st_data_t id;
   LmnFunctorEntry entry;
@@ -198,16 +193,16 @@ static LmnFunctor functor_intern(BOOL special, lmn_interned_str module,
     struct LmnFunctorEntry *new_entry;
 
     /* 必要ならばサイズを拡張 */
-    while (lmn_functor_table.next_id >= lmn_functor_table.size) {
-      lmn_functor_table.size *= 2;
-      lmn_functor_table.entry = LMN_REALLOC(
-          LmnFunctorEntry, lmn_functor_table.entry, lmn_functor_table.size);
+    while (this->next_id >= this->size) {
+      this->size *= 2;
+      this->entry = LMN_REALLOC(
+          LmnFunctorEntry, this->entry, this->size);
     }
 
     /* idはデータを格納する配列のインデックス */
-    id = lmn_functor_table.next_id++;
+    id = this->next_id++;
     /* idの位置にファンクタのデータをコピー */
-    lmn_functor_table.entry[id] = entry;
+    this->entry[id] = entry;
 
     /* ファンクタとIDの対応をテーブルに格納する */
     new_entry = LMN_MALLOC(struct LmnFunctorEntry);
@@ -218,7 +213,7 @@ static LmnFunctor functor_intern(BOOL special, lmn_interned_str module,
   }
 }
 
-LmnFunctor lmn_functor_intern(lmn_interned_str module, lmn_interned_str name,
+LmnFunctor LmnFunctorTable::lmn_functor_intern(lmn_interned_str module, lmn_interned_str name,
                               int arity) {
   return functor_intern(FALSE, module, name, arity);
 }

--- a/src/vm/functor.h
+++ b/src/vm/functor.h
@@ -85,8 +85,8 @@ public:
   unsigned int get_next_id();
 
   #ifdef DEBUG
-  void lmn_functor_tbl_print(void);
-  void lmn_functor_printer(LmnFunctor f);
+  void print(void);
+  void functor_printer(LmnFunctor f);
   #endif
 
 };

--- a/src/vm/functor.h
+++ b/src/vm/functor.h
@@ -65,10 +65,16 @@ public:
   void lmn_functor_printer(LmnFunctor f);
   #endif
 private:
+  LmnFunctor functor_intern(BOOL special, lmn_interned_str module,
+                                 lmn_interned_str name, int arity);
 public:
   void lmn_register_predefined_functor(void);//not found
   void lmn_functor_tbl_init(void);
   void lmn_functor_tbl_destroy(void);
+  LmnFunctor lmn_functor_intern(lmn_interned_str module, lmn_interned_str name,
+                              int arity);
+  void register_functor(int id, BOOL special, lmn_interned_str module,
+                             lmn_interned_str name, int arity);
 };
 
 typedef struct LmnFunctorEntry {
@@ -84,8 +90,6 @@ extern LmnFunctorTable lmn_functor_table;
 
 
 
-LmnFunctor lmn_functor_intern(lmn_interned_str module, lmn_interned_str name,
-                              int arity);
 
 /* predefined functors */
 

--- a/src/vm/functor.h
+++ b/src/vm/functor.h
@@ -80,10 +80,6 @@ public:
                              lmn_interned_str name, int arity);
   static int functor_entry_free(LmnFunctorEntry *e);
 
-  #define LMN_FUNCTOR_NAME_ID(F) (lmn_functor_table->get_entry(F)->name)
-  #define LMN_FUNCTOR_ARITY(F) (lmn_functor_table->get_entry(F)->arity)
-  #define LMN_FUNCTOR_MODULE_ID(F) (lmn_functor_table->get_entry(F)->module)
-
   LmnFunctorEntry *get_entry(unsigned int f);
   unsigned int get_size();
   unsigned int get_next_id();
@@ -94,6 +90,10 @@ public:
   #endif
 
 };
+
+#define LMN_FUNCTOR_NAME_ID(T,F) (T->get_entry(F)->name)
+#define LMN_FUNCTOR_ARITY(T,F) (T->get_entry(F)->arity)
+#define LMN_FUNCTOR_MODULE_ID(T,F) (T->get_entry(F)->module)
 
 extern LmnFunctorTable *lmn_functor_table;
 

--- a/src/vm/functor.h
+++ b/src/vm/functor.h
@@ -49,11 +49,27 @@
 
 /* Functor Information */
 
-typedef struct LmnFunctorTable {
+class LmnFunctorTable {
+public:
   unsigned int size;
   unsigned int next_id;
   struct LmnFunctorEntry *entry;
-} LmnFunctorTable;
+
+  /* アクセスを高速にするためにマクロにする */
+  #define LMN_FUNCTOR_NAME_ID(F) (lmn_functor_table.entry[(F)].name)
+  #define LMN_FUNCTOR_ARITY(F) (lmn_functor_table.entry[(F)].arity)
+  #define LMN_FUNCTOR_MODULE_ID(F) (lmn_functor_table.entry[(F)].module)  
+
+  #ifdef DEBUG
+  void lmn_functor_tbl_print(void);
+  void lmn_functor_printer(LmnFunctor f);
+  #endif
+private:
+public:
+  void lmn_register_predefined_functor(void);//not found
+  void lmn_functor_tbl_init(void);
+  void lmn_functor_tbl_destroy(void);
+};
 
 typedef struct LmnFunctorEntry {
   BOOL special;
@@ -62,23 +78,12 @@ typedef struct LmnFunctorEntry {
   LmnArity arity;
 } LmnFunctorEntry;
 
-extern struct LmnFunctorTable lmn_functor_table;
+extern LmnFunctorTable lmn_functor_table;
 
 #define FUNCTOR_MAX ((1 << (8 * sizeof(LmnFunctor))) - 1)
 
-/* アクセスを高速にするためにマクロにする */
-#define LMN_FUNCTOR_NAME_ID(F) (lmn_functor_table.entry[(F)].name)
-#define LMN_FUNCTOR_ARITY(F) (lmn_functor_table.entry[(F)].arity)
-#define LMN_FUNCTOR_MODULE_ID(F) (lmn_functor_table.entry[(F)].module)
 
-#ifdef DEBUG
-void lmn_functor_tbl_print(void);
-void lmn_functor_printer(LmnFunctor f);
-#endif
 
-void lmn_register_predefined_functor(void);
-void lmn_functor_tbl_init(void);
-void lmn_functor_tbl_destroy(void);
 LmnFunctor lmn_functor_intern(lmn_interned_str module, lmn_interned_str name,
                               int arity);
 

--- a/src/vm/functor.h
+++ b/src/vm/functor.h
@@ -70,7 +70,7 @@ public:
   void lmn_register_predefined_functor(void);//not found
   void lmn_functor_tbl_init(void);
   void lmn_functor_tbl_destroy(void);
-  LmnFunctor lmn_functor_intern(lmn_interned_str module, lmn_interned_str name,
+  LmnFunctor intern(lmn_interned_str module, lmn_interned_str name,
                               int arity);
   void register_functor(int id, BOOL special, lmn_interned_str module,
                              lmn_interned_str name, int arity);

--- a/src/vm/functor.h
+++ b/src/vm/functor.h
@@ -67,6 +67,8 @@ public:
 private:
   LmnFunctor functor_intern(BOOL special, lmn_interned_str module,
                                  lmn_interned_str name, int arity);
+  LmnFunctorEntry *lmn_id_to_functor(int functor_id) const;
+
 public:
   void lmn_register_predefined_functor(void);//not found
   void lmn_functor_tbl_init(void);
@@ -75,6 +77,8 @@ public:
                               int arity);
   void register_functor(int id, BOOL special, lmn_interned_str module,
                              lmn_interned_str name, int arity);
+  static int functor_entry_free(LmnFunctorEntry *e);
+
 };
 
 typedef struct LmnFunctorEntry {

--- a/src/vm/functor.h
+++ b/src/vm/functor.h
@@ -49,27 +49,24 @@
 
 /* Functor Information */
 
+struct LmnFunctorEntry {
+  BOOL special;
+  lmn_interned_str module;
+  lmn_interned_str name;
+  LmnArity arity;
+};
+
 class LmnFunctorTable {
-public:
+
   unsigned int size;
   unsigned int next_id;
-  struct LmnFunctorEntry *entry;
-
-  /* アクセスを高速にするためにマクロにする */
-  #define LMN_FUNCTOR_NAME_ID(F) (lmn_functor_table.entry[(F)].name)
-  #define LMN_FUNCTOR_ARITY(F) (lmn_functor_table.entry[(F)].arity)
-  #define LMN_FUNCTOR_MODULE_ID(F) (lmn_functor_table.entry[(F)].module)  
-
-  #ifdef DEBUG
-  void lmn_functor_tbl_print(void);
-  void lmn_functor_printer(LmnFunctor f);
-  #endif
-private:
+  LmnFunctorEntry *entry;
   LmnFunctor functor_intern(BOOL special, lmn_interned_str module,
                                  lmn_interned_str name, int arity);
   LmnFunctorEntry *lmn_id_to_functor(int functor_id) const;
-
 public:
+  static int functor_cmp(LmnFunctorEntry *x, LmnFunctorEntry *y);
+  static long functor_hash(LmnFunctorEntry *x);
   void lmn_register_predefined_functor(void);//not found
   void lmn_functor_tbl_init(void);
   void lmn_functor_tbl_destroy(void);
@@ -79,14 +76,20 @@ public:
                              lmn_interned_str name, int arity);
   static int functor_entry_free(LmnFunctorEntry *e);
 
-};
+  #define LMN_FUNCTOR_NAME_ID(F) (lmn_functor_table.get_entry(F)->name)
+  #define LMN_FUNCTOR_ARITY(F) (lmn_functor_table.get_entry(F)->arity)
+  #define LMN_FUNCTOR_MODULE_ID(F) (lmn_functor_table.get_entry(F)->module)
 
-typedef struct LmnFunctorEntry {
-  BOOL special;
-  lmn_interned_str module;
-  lmn_interned_str name;
-  LmnArity arity;
-} LmnFunctorEntry;
+  LmnFunctorEntry *get_entry(unsigned int f);
+  unsigned int get_size();
+  unsigned int get_next_id();
+
+  #ifdef DEBUG
+  void lmn_functor_tbl_print(void);
+  void lmn_functor_printer(LmnFunctor f);
+  #endif
+
+};
 
 extern LmnFunctorTable lmn_functor_table;
 

--- a/src/vm/functor.h
+++ b/src/vm/functor.h
@@ -46,6 +46,7 @@
  */
 
 #include "lmntal.h"
+#include "element/element.h"
 
 /* Functor Information */
 
@@ -61,24 +62,27 @@ class LmnFunctorTable {
   unsigned int size;
   unsigned int next_id;
   LmnFunctorEntry *entry;
+  st_table_t
+    functor_id_tbl; /* ファンクタ構造体からIDへの対応を要素に持つテーブル */
+
   LmnFunctor functor_intern(BOOL special, lmn_interned_str module,
                                  lmn_interned_str name, int arity);
   LmnFunctorEntry *lmn_id_to_functor(int functor_id) const;
 public:
+  LmnFunctorTable();
+  ~LmnFunctorTable();
   static int functor_cmp(LmnFunctorEntry *x, LmnFunctorEntry *y);
   static long functor_hash(LmnFunctorEntry *x);
   void lmn_register_predefined_functor(void);//not found
-  void lmn_functor_tbl_init(void);
-  void lmn_functor_tbl_destroy(void);
   LmnFunctor intern(lmn_interned_str module, lmn_interned_str name,
                               int arity);
   void register_functor(int id, BOOL special, lmn_interned_str module,
                              lmn_interned_str name, int arity);
   static int functor_entry_free(LmnFunctorEntry *e);
 
-  #define LMN_FUNCTOR_NAME_ID(F) (lmn_functor_table.get_entry(F)->name)
-  #define LMN_FUNCTOR_ARITY(F) (lmn_functor_table.get_entry(F)->arity)
-  #define LMN_FUNCTOR_MODULE_ID(F) (lmn_functor_table.get_entry(F)->module)
+  #define LMN_FUNCTOR_NAME_ID(F) (lmn_functor_table->get_entry(F)->name)
+  #define LMN_FUNCTOR_ARITY(F) (lmn_functor_table->get_entry(F)->arity)
+  #define LMN_FUNCTOR_MODULE_ID(F) (lmn_functor_table->get_entry(F)->module)
 
   LmnFunctorEntry *get_entry(unsigned int f);
   unsigned int get_size();
@@ -91,7 +95,7 @@ public:
 
 };
 
-extern LmnFunctorTable lmn_functor_table;
+extern LmnFunctorTable *lmn_functor_table;
 
 #define FUNCTOR_MAX ((1 << (8 * sizeof(LmnFunctor))) - 1)
 

--- a/src/vm/membrane.cpp
+++ b/src/vm/membrane.cpp
@@ -418,7 +418,7 @@ unsigned long lmn_mem_space(LmnMembraneRef mem) {
                     ret += internal_hashtbl_space(ent->record);
                   }
                   EACH_ATOM(atom, ent, ({
-                              ret += LMN_SATOM_SIZE(LMN_FUNCTOR_ARITY(
+                              ret += LMN_SATOM_SIZE(LMN_FUNCTOR_ARITY(lmn_functor_table, 
                                   atom->get_functor()));
                             }));
                 }));
@@ -2641,7 +2641,7 @@ static inline int mem_isomor_trace_symbols(LmnAtomRef cur1, LmnMembraneRef mem1,
   global_ret = MEM_ISOMOR_MATCH_WITHOUT_MEM;
 
   /* リンク先を辿る */
-  for (to_i = 0; to_i < LMN_FUNCTOR_ARITY(f); to_i++) {
+  for (to_i = 0; to_i < LMN_FUNCTOR_ARITY(lmn_functor_table, f); to_i++) {
     LmnLinkAttr attr1, attr2;
     LmnAtomRef atom1, atom2;
 

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -758,7 +758,7 @@ void slim::vm::interpreter::findatom_clone_hyperlink(
 void slim::vm::interpreter::findatom_through_hyperlink(
     LmnReactCxtRef rc, LmnRuleRef rule, LmnRuleInstr instr, SameProcCxt *spc,
     LmnMembrane *mem, LmnFunctor f, size_t reg) {
-  auto atom_arity = LMN_FUNCTOR_ARITY(f);
+  auto atom_arity = LMN_FUNCTOR_ARITY(lmn_functor_table, f);
 
   /* 型付きプロセス文脈atomiがoriginal/cloneのどちらであるか判別 */
   if (spc->is_clone(atom_arity)) {
@@ -1335,7 +1335,7 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
 
       READ_VAL(LmnFunctor, instr, f);
 
-      auto atom_arity = LMN_FUNCTOR_ARITY(f);
+      auto atom_arity = LMN_FUNCTOR_ARITY(lmn_functor_table, f);
 
       if (rc_hlink_opt(atomi, rc)) {
         SameProcCxt *spc;
@@ -4014,8 +4014,8 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
 
     if (!LMN_ATTR_IS_DATA(atom->get_attr(0))) {
       LmnSymbolAtomRef f_name = (LmnSymbolAtomRef)atom->get_link(0);
-      lmn_interned_str name = LMN_FUNCTOR_NAME_ID(f_name->get_functor());
-      int arity = LMN_FUNCTOR_ARITY(atom->get_functor());
+      lmn_interned_str name = LMN_FUNCTOR_NAME_ID(lmn_functor_table, f_name->get_functor());
+      int arity = LMN_FUNCTOR_ARITY(lmn_functor_table, atom->get_functor());
 
       c = get_ccallback(name);
       if (!c)
@@ -4899,8 +4899,8 @@ static BOOL dmem_interpret(LmnReactCxtRef rc, LmnRuleRef rule,
 
       if (!LMN_ATTR_IS_DATA(atom->get_attr(0))) {
         LmnSymbolAtomRef f_name = (LmnSymbolAtomRef)atom->get_link(0);
-        lmn_interned_str name = LMN_FUNCTOR_NAME_ID(f_name->get_functor());
-        int arity = LMN_FUNCTOR_ARITY(atom->get_functor());
+        lmn_interned_str name = LMN_FUNCTOR_NAME_ID(lmn_functor_table, f_name->get_functor());
+        int arity = LMN_FUNCTOR_ARITY(lmn_functor_table, atom->get_functor());
 
         c = get_ccallback(name);
         if (!c)


### PR DESCRIPTION
インスタンスが１つしかなかったので全部staticにしようかと思いましたが後から機能を追加する可能性を否定できなかったのでexternをそのまま残しました　cppでしか宣言されてない関数をprivateにするとエラーが出たので不要なincludeがあるのかもしれません