### PR TITLE
Add ant to pre-install packages for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,13 @@ matrix:
   - if: branch = develop OR branch = master
     compiler: clang
     env: slim_CHECK_ND=yes
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y ant re2c
 install:
   - git clone https://github.com/lmntal/lmntal-compiler.git
   - cd lmntal-compiler && ant compile && cd ..
   - export LMNTAL_HOME="`pwd`/lmntal-compiler"
-  - sudo apt-get -qq update
-  - sudo apt-get install -y re2c
 script:
   - ./autogen.sh
   - ./configure $DEBUG_FLAG


### PR DESCRIPTION
Travis CIが急にantを認識しなくなったのでinstallコマンドを追加。