### PR TITLE
スペシャルアトム（state_map, set）のfreeの修正

### DIFF
--- a/lib/set.lmn
+++ b/lib/set.lmn
@@ -57,6 +57,7 @@ HISTORY
 
   set.free(Set) :- class(Set, "set") |
       '$callback'('cb_set_free', Set).
+  set.free(set_empty) :- .
 
   Ret = set.insert(Set, Val) :- class(Set, "set") |
       '$callback'('cb_set_insert', Set, Val, Ret).

--- a/src/ext/state_map.cpp
+++ b/src/ext/state_map.cpp
@@ -79,7 +79,7 @@ void cb_state_map_init(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
 
 void cb_state_map_free(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
                        LmnLinkAttr t0) {
-  delete (LmnStateMapRef)a0, mem;
+  delete ((LmnStateMapRef)a0)->states, mem;
   lmn_mem_remove_data_atom(mem, (LmnDataAtomRef)a0, t0);
 }
 


### PR DESCRIPTION
- `state_space.state_map_free` がSEGVする問題を修正
  + 単に二重解放だった
- 空集合に対するfree: `set.free(set_empty)` が動作しない問題を修正
  + そもそも空集合 `set_empty` だけシンボルアトムにする理由が分からないが……