### PR TITLE
State modify2

### DIFF
--- a/src/verifier/mem_encode/encoder.hpp
+++ b/src/verifier/mem_encode/encoder.hpp
@@ -248,7 +248,7 @@ class encoder {
     BinStrCursor last_valid_bsp;
     Iterator last_valid_it = end;
     int first_func = 0;
-    CheckpointRef last_valid_checkpoint = NULL;
+    CheckpointRef last_valid_checkpoint = nullptr;
 
     
     if (!bsp.is_valid())
@@ -273,17 +273,17 @@ class encoder {
 
       write_mol(atom, LMN_ATTR_MAKE_LINK(0), -1, new_bsptr, visited, TRUE);
       if (new_bsptr.is_valid()) {
-        /* atomからたどった分子が書き込みに成功したので次のアトムの書き込みを試みる */
+        /* atomからたどった分子が書き込みに成功したのでlast_validに記憶する */
         
-	if (last_valid_it == end) {
-	  first_func = atom->get_functor();
-	} else {
-	  delete last_valid_checkpoint;
-	}
-
-	last_valid_bsp = new_bsptr;
-	last_valid_checkpoint = visited->pop_checkpoint();
-	last_valid_it = it;
+        if (last_valid_it == end) {
+          first_func = atom->get_functor();
+        } else {
+          delete last_valid_checkpoint;
+        }
+        
+        last_valid_bsp = new_bsptr;
+        last_valid_checkpoint = visited->pop_checkpoint();
+        last_valid_it = it;
       } else {
         visited->revert_checkpoint();
       }

--- a/src/verifier/mem_encode/encoder.hpp
+++ b/src/verifier/mem_encode/encoder.hpp
@@ -275,15 +275,15 @@ class encoder {
       if (new_bsptr.is_valid()) {
         /* atomからたどった分子が書き込みに成功したので、last_validに記憶する */
         
-	if (last_valid_it == end) {
-	  first_func = atom->get_functor();
-	} else {
-	  delete last_valid_checkpoint;
-	}
-	
-	last_valid_bsp = new_bsptr;
-	last_valid_checkpoint = visited->pop_checkpoint();
-	last_valid_it = it;
+        if (last_valid_it == end) {
+          first_func = atom->get_functor();
+        } else {
+          delete last_valid_checkpoint;
+        }
+        
+        last_valid_bsp = new_bsptr;
+        last_valid_checkpoint = visited->pop_checkpoint();
+        last_valid_it = it;
       } else {
         visited->revert_checkpoint();
       }


### PR DESCRIPTION
# 状態数バグ修正


Issue「状態数に関する問題 #243」を解決するために，
プルリク「状態数バグ修正 #246」が化たプルレクです．

- `verifier/mem_encoder/encoder.hpp`（のみ）を修正しています．
- （基本的に）上記ファイルの中でも，関数`write_mols`のみを修正しています
- 修正方法は，問題が最初に発生したコミット（a175161）の一つ前のコミット（1e739bc）からのコピペです\(^^)/
- ただし，元々はベクタに添字アクセスしていたので，一部イテレータに書き直しました．


`--mem-enc`や`--disable-opt-hash`をつけてもつけなくとも，状態数が同じであることを
```
a(a(a(a(a(a(a(a(a(L)))))))),L).
a(X,Y) :- b(X,Y).
```
```
a(a(a(L)), L).
a(X, Y) :- b(X, Y).
```
やベンチマークセット内の`phiM.lmn`，`phi.lmn`でテストしました．

（正直，件の関数内部で何をしているのか正確に把握しているわけでは全くないので，テストやリファクタリングは不可欠だと思います）

