### PR TITLE
Fix bugs in deleteconnectors instruction applied to data atoms.

### DIFF
--- a/src/vm/membrane.cpp
+++ b/src/vm/membrane.cpp
@@ -427,10 +427,25 @@ void lmn_mem_unify_symbol_atom_args(LmnSymbolAtomRef atom1, int pos1,
   ap2 = atom2->get_link(pos2);
   attr2 = atom2->get_attr(pos2);
 
-  ((LmnSymbolAtomRef)ap2)->set_link(attr2, ap1);
-  ((LmnSymbolAtomRef)ap2)->set_attr(attr2, attr1);
-  ((LmnSymbolAtomRef)ap1)->set_link(attr1, ap2);
-  ((LmnSymbolAtomRef)ap1)->set_attr(attr1, attr2);
+  if (LMN_ATTR_IS_DATA(attr1)) {
+    std::swap(ap1, ap2);
+    std::swap(attr1, attr2);
+  }
+
+  if (LMN_ATTR_IS_DATA(attr1) && LMN_ATTR_IS_DATA(attr2)) {
+    // TODO: '='アトムでつなぐ？
+    // SLIMの仕様上はここにこないはずだが……
+    // というかそれができるならlmn_mem_unify_atom_argsでいい．
+    lmn_fatal("cannot connect data atoms here.");
+  } else if (LMN_ATTR_IS_DATA(attr2)) {
+    ((LmnSymbolAtomRef)ap1)->set_link(attr1, ap2);
+    ((LmnSymbolAtomRef)ap1)->set_attr(attr1, attr2);
+  } else {
+    ((LmnSymbolAtomRef)ap2)->set_link(attr2, ap1);
+    ((LmnSymbolAtomRef)ap2)->set_attr(attr2, attr1);
+    ((LmnSymbolAtomRef)ap1)->set_link(attr1, ap2);
+    ((LmnSymbolAtomRef)ap1)->set_attr(attr1, attr2);
+  }
 }
 
 /* atom1, atom2はシンボルアトムのはず */


### PR DESCRIPTION
```
eval(C), $c[E, C], E = add(X, Y) :-
	$z=X + Y, ground($c) |
	eval(C), $c[Z, C], Z = $z.

eval(add(1, 2)).
```
上記コードを実行したときにdeleteconnectorsでSegmentation faultしていたのを修正．
deleteconnectorsは型付プロセス（ground）のコピーの際にinsertconnectorsとともに使われる命令で，insertconnectorsによって生成された'='/2アトムを削除する．
このとき，'='/2アトムの片方にデータアトムがあるとクラッシュしていた．
上記再現コードのようにデータアトムにgroundでマッチすると（条件によっては？）発生する．

SLIMではデータアトム同士が直接繋がることはないので，deleteconnectors実行時に'='/2アトムの両方がデータアトムになるような状況は起きないはず．