### PR TITLE
add 2 intermidiate instruction: "int2float" and "float2int"

### DIFF
--- a/src/element/instruction.cpp
+++ b/src/element/instruction.cpp
@@ -206,6 +206,11 @@ const std::map<LmnInstruction, InstrSpec> instr_spec = {
     {INSTR_ISFLOAT, {"isfloat", {InstrVar}}},
     {INSTR_ISSTRING, {"isstring", {InstrVar}}},
 
+    {INSTR_FLOAT2INT, {"float2int", {InstrVar, InstrVar}}},
+    {INSTR_INT2FLOAT, {"int2float", {InstrVar, InstrVar}}},
+    {INSTR_FLOAT2INTFUNC, {"float2intfunc", {InstrVar, InstrVar}}},
+    {INSTR_INT2FLOATFUNC, {"int2floatfunc", {InstrVar, InstrVar}}},
+
     {INSTR_UNIQ, {"uniq", {InstrVarList}}},
 
     /* guard: hyperlink */

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -3697,6 +3697,42 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
       return FALSE;
     break;
   }
+  case INSTR_FLOAT2INT: {
+    LmnInstrVar dstatom, atomi;
+    READ_VAL(LmnInstrVar, instr, dstatom);
+    READ_VAL(LmnInstrVar, instr, atomi);
+    rc->reg(dstatom) = {
+      static_cast<LmnWord>((long)lmn_get_double(rc->wt(atomi))),
+      LMN_INT_ATTR, TT_ATOM};
+    break;
+  }
+  case INSTR_INT2FLOAT: {
+    LmnInstrVar dstatom, atomi;
+    LmnAtom d;
+    READ_VAL(LmnInstrVar, instr, dstatom);
+    READ_VAL(LmnInstrVar, instr, atomi);
+    d = lmn_create_double_atom((double)rc->wt(atomi));
+    rc->reg(dstatom) = {d, LMN_DBL_ATTR, TT_ATOM};
+    break;
+  }
+  case INSTR_FLOAT2INTFUNC: {
+    LmnInstrVar dstatom, funci;
+    READ_VAL(LmnInstrVar, instr, dstatom);
+    READ_VAL(LmnInstrVar, instr, funci);
+    rc->reg(dstatom) = {
+      static_cast<LmnWord>((long)lmn_get_double(rc->wt(funci))),
+      LMN_INT_ATTR, TT_OTHER};
+    break;
+  }
+  case INSTR_INT2FLOATFUNC: {
+    LmnInstrVar dstatom, funci;
+    LmnAtom d;
+    READ_VAL(LmnInstrVar, instr, dstatom);
+    READ_VAL(LmnInstrVar, instr, funci);
+    d = lmn_create_double_atom((double)rc->wt(funci));
+    rc->reg(dstatom) = {d, LMN_DBL_ATTR, TT_OTHER};
+    break;
+  }
   case INSTR_ALLOCATOM: {
     LmnInstrVar atomi;
     LmnLinkAttr attr;


### PR DESCRIPTION
slim に中間命令 `float2int` 及び `int2float` を搭載しました。
lmntal-compiler への実装と併せて、`slim` コマンドで正しく動作することが確認できました。

すでに src/element/instruction.hpp ファイルの `enum LmnInstruction` には追加されていたので、
https://github.com/lmntal/slim/blob/fdbb018a32dbe3d7d57f0f83f5c52eef76d6782b/src/element/instruction.hpp#L243-L246
src/element/instruction.cpp ファイルの `const std::map<LmnInstruction, InstrSpec> instr_spec` に次を追加し、マップを生成。
https://github.com/lmntal/slim/blob/fdbb018a32dbe3d7d57f0f83f5c52eef76d6782b/src/element/instruction.cpp#L209-L212
続いて src/vm/task.cpp ファイルの `slim::vm::interpreter::exec_command` 関数内の `switch (op)` の `case` に以下を追加。
https://github.com/lmntal/slim/blob/fdbb018a32dbe3d7d57f0f83f5c52eef76d6782b/src/vm/task.cpp#L3700-L3735
ここで `float2int` 及び `int2float` の実行内容を実装している。