### PR TITLE
Feature/extended ground

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,8 +29,9 @@ DX_INIT_DOXYGEN(SLIM, doc/doxygen.cfg, doc/doxygen)
 # Checks for programs.
 #
 
-CFLAGS="-O -std=c11 -D_XOPEN_SOURCE=700 -Wall $CFLAGS"
-CXXFLAGS="-O2 -std=c++11 $CXXFLAGS"
+CFLAGS="-O -std=c11 -g -fno-omit-frame-pointer -D_XOPEN_SOURCE=700 -Wall $CFLAGS"
+# CXXFLAGS="-O2 -std=c++11 -g -fsanitize=address -fno-omit-frame-pointer $CXXFLAGS"
+CXXFLAGS="-O -std=c++11 -g -fno-omit-frame-pointer $CXXFLAGS"
 
 case "$host" in
   *-*-darwin* | *-*-ios*)

--- a/configure.ac
+++ b/configure.ac
@@ -29,8 +29,10 @@ DX_INIT_DOXYGEN(SLIM, doc/doxygen.cfg, doc/doxygen)
 # Checks for programs.
 #
 
+# CFLAGS="-O -std=c11 -g -fsanitize=address -fno-omit-frame-pointer -D_XOPEN_SOURCE=700 -Wall $CFLAGS"
 CFLAGS="-O -std=c11 -g -fno-omit-frame-pointer -D_XOPEN_SOURCE=700 -Wall $CFLAGS"
-# CXXFLAGS="-O2 -std=c++11 -g -fsanitize=address -fno-omit-frame-pointer $CXXFLAGS"
+# CXXFLAGS="-O -std=c++11 -g -fsanitize=address -fno-omit-frame-pointer $CXXFLAGS"
+# CXXFLAGS="-O2 -std=c++11 -g -fno-omit-frame-pointer $CXXFLAGS"
 CXXFLAGS="-O -std=c++11 -g -fno-omit-frame-pointer $CXXFLAGS"
 
 case "$host" in

--- a/src/element/re2c/buffer.cpp
+++ b/src/element/re2c/buffer.cpp
@@ -45,6 +45,12 @@ buffer::buffer(int fill_size, int size)
     : fill_size(fill_size), size(size), buf(new char[fill_size + size]),
       YYLIMIT(buf + size), YYCURSOR(YYLIMIT), parsed_pos(YYLIMIT) {}
 
+buffer::~buffer() {
+  if(this->buf != NULL) {
+    delete[] buf;
+  }
+}
+
 bool buffer::fill(size_t need) {
   if (is_finished())
     return false;

--- a/src/element/re2c/buffer.hpp
+++ b/src/element/re2c/buffer.hpp
@@ -55,7 +55,8 @@ public:
 
   buffer(int fill_size, int size = 256);
   // virtual ~buffer() {}
-  ~buffer();
+  virtual ~buffer();
+  //  ~buffer();
   virtual bool is_finished() const = 0;
   virtual void update_limit(size_t free) = 0;
 

--- a/src/element/re2c/buffer.hpp
+++ b/src/element/re2c/buffer.hpp
@@ -54,7 +54,8 @@ public:
   char *parsed_pos;
 
   buffer(int fill_size, int size = 256);
-  virtual ~buffer() {}
+  // virtual ~buffer() {}
+  ~buffer();
   virtual bool is_finished() const = 0;
   virtual void update_limit(size_t free) = 0;
 

--- a/src/ext/integer.cpp
+++ b/src/ext/integer.cpp
@@ -89,11 +89,11 @@ void integer_set(LmnReactCxtRef rc,
   for (i = 0, n = start; n <= end; i++, n++) {
     Vector *dstlovec;
     ProcessTableRef atommap;
+    ProcessTableRef hlinkmap = NULL;
     LinkObjRef l;
 
     lmn_mem_copy_ground(mem, srcvec, &dstlovec,
-                            // &atommap);
-			&atommap, NULL, NULL, NULL, NULL);  // extended
+			&atommap, &hlinkmap, NULL, NULL, NULL);  // extended
 
     l = (LinkObjRef)dstlovec->get(0);
     lmn_mem_newlink(mem, (LmnAtomRef)n, LMN_INT_ATTR, 0,
@@ -103,6 +103,7 @@ void integer_set(LmnReactCxtRef rc,
     for (int j = 0; j < dstlovec->get_num(); j++) LMN_FREE(dstlovec->get(j));
     delete dstlovec;
     delete atommap;
+    delete hlinkmap;
   }
 
   lmn_mem_delete_atom(mem, a0, t0);

--- a/src/ext/integer.cpp
+++ b/src/ext/integer.cpp
@@ -91,7 +91,9 @@ void integer_set(LmnReactCxtRef rc,
     ProcessTableRef atommap;
     LinkObjRef l;
 
-    lmn_mem_copy_ground(mem, srcvec, &dstlovec, &atommap);
+    lmn_mem_copy_ground(mem, srcvec, &dstlovec,
+                            // &atommap);
+			&atommap, NULL, NULL, NULL, NULL);  // extended
 
     l = (LinkObjRef)dstlovec->get(0);
     lmn_mem_newlink(mem, (LmnAtomRef)n, LMN_INT_ATTR, 0,

--- a/src/lmntal.h
+++ b/src/lmntal.h
@@ -218,6 +218,19 @@ LMN_EXTERN void lmn_free(void *p);
  * Global data
  */
 
+/* hlground info  // extended
+ * */
+typedef struct ProcessTbl *ProcessTableRef;
+typedef struct SimpleProcessTable *SimplyProcessTableRef;
+typedef struct Hlground_Data Hlground_Data;
+struct Hlground_Data {
+  ProcessTableRef global_hlinks;  // global hlinks
+  ProcessTableRef local_atoms;    // atoms within hlground
+};
+
+// extern Hlground_Data hlground_data;
+
+
 /* 階層グラフ構造の出力形式 */
 enum OutputFormat { DEFAULT = 1, DEV, DOT, JSON };
 enum MCdumpFormat { CUI, LaViT, Dir_DOT, LMN_FSM_GRAPH, LMN_FSM_GRAPH_MEM_NODE, LMN_FSM_GRAPH_HL_NODE };

--- a/src/lmntal.h
+++ b/src/lmntal.h
@@ -218,19 +218,6 @@ LMN_EXTERN void lmn_free(void *p);
  * Global data
  */
 
-/* hlground info  // extended
- * */
-typedef struct ProcessTbl *ProcessTableRef;
-typedef struct SimpleProcessTable *SimplyProcessTableRef;
-typedef struct Hlground_Data Hlground_Data;
-struct Hlground_Data {
-  ProcessTableRef global_hlinks;  // global hlinks
-  ProcessTableRef local_atoms;    // atoms within hlground
-};
-
-// extern Hlground_Data hlground_data;
-
-
 /* 階層グラフ構造の出力形式 */
 enum OutputFormat { DEFAULT = 1, DEV, DOT, JSON };
 enum MCdumpFormat { CUI, LaViT, Dir_DOT, LMN_FSM_GRAPH, LMN_FSM_GRAPH_MEM_NODE, LMN_FSM_GRAPH_HL_NODE };

--- a/src/loader/byte_encoder.hpp
+++ b/src/loader/byte_encoder.hpp
@@ -129,6 +129,13 @@ private:
 
     for (int i = 0; i < arg_num; i++)
       c17::visit(loader(*this), inst.args[i]);
+
+    /* ISGROUNDとCOPYGROUNDは引数の数が3と4の場合がある。3の場合は
+       第４引数として空リストを追加する */
+    if (inst.id == INSTR_ISGROUND || inst.id == INSTR_COPYGROUND 
+	&& arg_num == 3) {
+      write_forward<LmnInstrVar>(0);
+    }
   }
 
   /* 現在の位置に書き込TYPE型のデータを書き込む */

--- a/src/loader/byte_encoder.hpp
+++ b/src/loader/byte_encoder.hpp
@@ -132,9 +132,10 @@ private:
 
     /* ISGROUNDとCOPYGROUNDは引数の数が3と4の場合がある。3の場合は
        第４引数として空リストを追加する */
-    if (inst.id == INSTR_ISGROUND || inst.id == INSTR_COPYGROUND 
-	&& arg_num == 3) {
-      write_forward<LmnInstrVar>(0);
+    if (inst.id == INSTR_ISGROUND || inst.id == INSTR_COPYGROUND) {
+      if (arg_num == 3) {
+	write_forward<LmnInstrVar>(0);
+      }
     }
   }
 

--- a/src/loader/translate_generator.in
+++ b/src/loader/translate_generator.in
@@ -602,7 +602,8 @@ BOOL interpret_generated(LmnReactCxtRef rc,
     Vector *dstlovec, *retvec;
     ProcessTableRef atommap;
 
-    lmn_mem_copy_ground((LmnMembraneRef)rc->wt($2), srcvec, &dstlovec, &atommap);
+    lmn_mem_copy_ground((LmnMembraneRef)rc->wt($2), srcvec, &dstlovec, &atommap,
+                        NULL, NULL, NULL, NULL);
     Task::free_links(srcvec);
 
     /* 返り値の作成 */

--- a/src/verifier/mc.cpp
+++ b/src/verifier/mc.cpp
@@ -87,6 +87,8 @@ void run_mc(Vector *start_rulesets, AutomataRef a, Vector *psyms) {
     mem->drop();
     delete mem;
   }
+
+  delete start_rulesets;
 }
 
 static inline void do_mc(LmnMembraneRef world_mem_org, AutomataRef a,

--- a/src/vm/atom.cpp
+++ b/src/vm/atom.cpp
@@ -262,6 +262,7 @@ LmnSymbolAtomRef lmn_copy_satom_with_data(LmnSymbolAtomRef atom,
   for (i = 0; i < arity; i++) {
     if (LMN_ATTR_IS_DATA(atom->get_attr(i))) {
       if (is_new_hl && atom->get_attr(i) == LMN_HL_ATTR) {
+	// fprintf(stderr,"new hyperlink being created, %d\n", i);  // extended
         LmnAtomRef hlAtom = atom->get_link(i);
         HyperLink *hl = lmn_hyperlink_at_to_hl((LmnSymbolAtomRef)hlAtom);
         LmnAtomRef new_hlAtom = lmn_hyperlink_new_with_attr(
@@ -270,6 +271,8 @@ LmnSymbolAtomRef lmn_copy_satom_with_data(LmnSymbolAtomRef atom,
         newatom->set_attr(i, LMN_HL_ATTR);
         ((LmnSymbolAtomRef)new_hlAtom)->set_link(0, newatom);
         ((LmnSymbolAtomRef)new_hlAtom)->set_attr(0,LMN_ATTR_MAKE_LINK(i));
+	// fprintf(stderr,"new hyperlink: %4lu\n",
+	// 	LMN_HL_ID(lmn_hyperlink_at_to_hl((LmnSymbolAtomRef)new_hlAtom)));
       } else {
         LmnDataAtomRef dt =
             lmn_copy_data_atom((LmnDataAtomRef)atom->get_link(i),

--- a/src/vm/atom.h
+++ b/src/vm/atom.h
@@ -79,10 +79,15 @@ typedef LmnWord LmnDataAtomRef;
  *  * Link Attribute
  *     リンク属性は, 先頭1ビットが立っていない場合は,
  * 下位7bitが接続先リンクの番号を記録しており, 先頭1ビットが立っている場合は,
- * Primitiveデータの種類を記録する。 [Link Number]  0------- [int]          1000
- * 0000 [double]       1000 0001 [special]      1000 0011 [string]       1000
- * 0011 [const string] 1000 0100 [const double] 1000 0101 [hyper link]   1000
- * 1010
+ * Primitiveデータの種類を記録する。 
+ * [Link Number]  0------- 
+ * [int]          1000 0000 
+ * [double]       1000 0001 
+ * [special]      1000 0011 
+ * [string]       1000 0011
+ * [const string] 1000 0100
+ * [const double] 1000 0101
+ * [hyper link]   1000 1010
  *
  *     We are going to support some primitive data types.
  *     (signed/unsigned) int, short int, long int, byte, long long int,

--- a/src/vm/dumper.cpp
+++ b/src/vm/dumper.cpp
@@ -237,10 +237,12 @@ static BOOL dump_data_atom(LmnPortRef port, LmnAtomRef data, LmnLinkAttr attr) {
     char buf[18];
     port_put_raw_s(port, EXCLAMATION_NAME);
     if (lmn_env.show_hyperlink) {
-      sprintf(buf, "H%lx",
+      // sprintf(buf, "H%lx",
+      sprintf(buf, "H%lu",
               LMN_HL_ID(lmn_hyperlink_at_to_hl((LmnSymbolAtomRef)data)));
     } else {
-      sprintf(buf, "H%lx",
+      // sprintf(buf, "H%lx",
+      sprintf(buf, "H%lu",
               LMN_HL_ID(LMN_HL_ATOM_ROOT_HL((LmnSymbolAtomRef)data)));
     }
     if (LMN_HL_HAS_ATTR(lmn_hyperlink_at_to_hl((LmnSymbolAtomRef)data))) {
@@ -609,16 +611,22 @@ static void lmn_dump_cell_internal(LmnPortRef port, LmnMembraneRef mem,
           continue;
         EACH_ATOM(
             atom, ent, ({
+		// fprintf(stderr,"dump_cell_internal: %s/%d Addr[%p] ID[%lu]\n ",
+		// 	atom->str(), atom->get_arity(), atom, atom->get_id());
               int arity = atom->get_arity();
-              if (atom->get_functor() == LMN_RESUME_FUNCTOR)
+              if (atom->get_functor() == LMN_RESUME_FUNCTOR) {
                 continue;
+	      }
+	      // fprintf(stderr,"dump_cell_internal2:%s/%d\n", atom->str(), atom->get_arity());
               if (f == LMN_IN_PROXY_FUNCTOR || f == LMN_OUT_PROXY_FUNCTOR) {
                 pred_atoms[PROXY].push((LmnWord)atom);
               }
               /* 0 argument atom */
               else if (arity == 0) {
-		if(!atom->record_flag) 
+		if(!atom->record_flag) {
 		  pred_atoms[P0].push((LmnWord)atom);
+		  // fprintf(stderr, "pushed to P0\n");
+		}
               }
               /* 1 argument, link to the last argument */
               else if (arity == 1 && f != LMN_NIL_FUNCTOR &&
@@ -627,18 +635,38 @@ static void lmn_dump_cell_internal(LmnPortRef port, LmnMembraneRef mem,
                             ((LmnSymbolAtomRef)atom->get_link(0))->get_arity() -
                                 1)) {
                 pred_atoms[P1].push((LmnWord)atom);
+		// fprintf(stderr, "pushed to P1\n");
               }
               /* link to the last argument */
-              else if (arity > 1 &&
+              else {
+		// if文の条件が複雑なのでデバッグ用に残しておく
+		// BOOL c1 = arity > 1;  // should be true
+		// BOOL c2 = c1 && LMN_ATTR_IS_DATA(atom->get_attr(arity - 1));
+		// fprintf(stderr,"case 3: last_attr_is_data=%d, ", c2); fflush(stderr);
+		// BOOL c3 = false;
+		// if (c1 && !c2) {
+		//   int k = (int)LMN_ATTR_GET_VALUE(atom->get_attr(arity - 1));
+		//   fprintf(stderr,"last_attr=%d, ", k); fflush(stderr);
+		//   LmnSymbolAtomRef a = (LmnSymbolAtomRef)atom->get_link(arity - 1);
+		//   fprintf(stderr,"last_atom=%s/%d (%p), ", a->str(), a->get_arity(), a); fflush(stderr);
+		//   fprintf(stderr,"last_atom=%p, ", a); fflush(stderr);
+		//   int l = a->get_arity() - 1;
+		//   c3 = (k == l);
+		// }
+		if (arity > 1 &&
                        (LMN_ATTR_IS_DATA(atom->get_attr(arity - 1)) ||
                         (int)LMN_ATTR_GET_VALUE(
                             atom->get_attr(arity - 1)) ==
                             ((LmnSymbolAtomRef)atom->get_link(arity - 1))->get_arity() -
                                 1)) {
+	      // if (c1 && (c2 || c3)) {
                 pred_atoms[P2].push((LmnWord)atom);
+		// fprintf(stderr, "pushed to P2\n");
               } else {
                 pred_atoms[P3].push((LmnWord)atom);
+		// fprintf(stderr, "pushed to P3\n");
               }
+	      }
             }));
       }));
 
@@ -717,6 +745,8 @@ void lmn_dump_cell(LmnMembraneRef mem, LmnPortRef port, OutputFormat format) {
     break;
   case DEV:
     lmn_dump_mem_dev(mem);
+    lmn_dump_cell_nonewline(port, mem); // ueda
+    port_put_raw_s(port, "\n");
     break;
   case JSON:
     lmn_dump_mem_json(mem);
@@ -784,6 +814,7 @@ void dump_atom_dev(LmnSymbolAtomRef atom) {
 
   for (i = 0; i < arity; i++) {
     LmnLinkAttr attr;
+    LmnWord id2;
 
     fprintf(stdout, "   %2u: ", i);
     attr = atom->get_attr(i);
@@ -801,6 +832,13 @@ void dump_atom_dev(LmnSymbolAtomRef atom) {
       fprintf(stdout, " link[%5d, Addr:%p,    ID:%2lu], ",
               LMN_ATTR_GET_VALUE(attr), atom->get_link(i),
               ((LmnSymbolAtomRef)atom->get_link(i))->get_id());
+      // checking buddy
+      id2 = ((LmnSymbolAtomRef)
+	     ((LmnSymbolAtomRef)atom->get_link(i))->get_link(atom->get_attr(i)))->get_id();
+      fprintf(stdout,"buddy check:%2lu", id2);
+      if (id2 != atom->get_id()) {
+	fprintf(stdout," ****ILL-FORMED!!****");
+      }
     } else {
       switch (attr) {
       case LMN_INT_ATTR:
@@ -814,6 +852,13 @@ void dump_atom_dev(LmnSymbolAtomRef atom) {
         fprintf(stdout, "hlink[ !, Addr:%lu, ID:%lu], ",
                 (LmnWord)atom->get_link(i),
                 ((LmnSymbolAtomRef)atom->get_link(i))->get_id());
+        // checking buddy
+	id2 = ((LmnSymbolAtomRef)
+	       ((LmnSymbolAtomRef)atom->get_link(i))->get_link(0))->get_id();
+	fprintf(stdout,"buddy check:%2lu", id2);
+	if (id2 != atom->get_id()) {
+	  fprintf(stdout," ****ILL-FORMED!!****");
+	}
         break;
       default:
         fprintf(stdout, "unknown data type[%d], ", attr);

--- a/src/vm/hyperlink.cpp
+++ b/src/vm/hyperlink.cpp
@@ -200,7 +200,8 @@ void lmn_hyperlink_delete(LmnSymbolAtomRef at) {
       }
     }
 
-    LMN_FREE(hl);
+    // LMN_FREE(hl);
+    delete hl;
   }
 }
 

--- a/src/vm/hyperlink.cpp
+++ b/src/vm/hyperlink.cpp
@@ -560,14 +560,16 @@ BOOL hyperlink_print(LmnMembraneRef mem, BOOL *flag, int *group, int *element) {
 
                 /* hl_ID */
                 //      fprintf(f, "%9lx", LMN_ATOM(atom));
-                fprintf(f, "%9lx", LMN_HL_ID(lmn_hyperlink_at_to_hl(atom)));
+                // fprintf(f, "%9lx", LMN_HL_ID(lmn_hyperlink_at_to_hl(atom)));
+		fprintf(f, "%9lu", LMN_HL_ID(lmn_hyperlink_at_to_hl(atom)));
                 //      fprintf(f, "%9lx",
                 //      LMN_HL_ID(lmn_hyperlink_get_root(lmn_hyperlink_at_to_hl(atom))));
 
                 /* parent */
                 if ((parent = hl->parent) != hl) {
                   //        fprintf(f, " %9lx", LMN_ATOM(parent->atom));
-                  fprintf(f, " %9lx", LMN_HL_ID(parent));
+                  // fprintf(f, " %9lx", LMN_HL_ID(parent));
+                  fprintf(f, " %9lu", LMN_HL_ID(parent));
                 } else {
                   (*group)++;
                   fprintf(f, " %9s", "root");
@@ -611,7 +613,8 @@ BOOL hyperlink_print(LmnMembraneRef mem, BOOL *flag, int *group, int *element) {
                       }
 
                       //            fprintf(f, "%lx", LMN_ATOM(ch_hl->atom));
-                      fprintf(f, "%lx%n", LMN_HL_ID(ch_hl), &n);
+                      // fprintf(f, "%lx%n", LMN_HL_ID(ch_hl), &n);
+                      fprintf(f, "%lu%n", LMN_HL_ID(ch_hl), &n);
                       width += n;
                       i++;
                     }

--- a/src/vm/membrane.cpp
+++ b/src/vm/membrane.cpp
@@ -2012,7 +2012,7 @@ void dfs_scope_finder(
       }
       else  
       {
-          printf("neither a regular link or a hyperlink: means an undefined link  \n");
+          // printf("neither a regular link or a hyperlink: means an undefined link  \n");
       }
     }
     else                        //current link is a regular link

--- a/src/vm/membrane.cpp
+++ b/src/vm/membrane.cpp
@@ -483,7 +483,7 @@ void lmn_mem_unify_atom_args(LmnMembraneRef mem, LmnSymbolAtomRef atom1,
        //   a1->get_id(), pos1, a1->get_attr(pos1), ((LmnSymbolAtomRef)a1->get_link(0))->get_id(),
        //   a2->get_id(), pos2, a2->get_attr(pos2), ((LmnSymbolAtomRef)a2->get_link(attr2))->get_id()); 
      } else {
-       fprintf(stdout,"LMN_ATTR_IS_DATA(attr1)\n");
+       // fprintf(stdout,"LMN_ATTR_IS_DATA(attr1)\n");
        ((LmnSymbolAtomRef)ap2)->set_link(attr2, ap1);
        ((LmnSymbolAtomRef)ap2)->set_attr(attr2, attr1);
      }

--- a/src/vm/membrane.h
+++ b/src/vm/membrane.h
@@ -59,35 +59,35 @@ typedef struct LinkObj *LinkObjRef;
 
 #include <vector>
 
-
 /*
- * Global variable
- * */
+ * extended ground
+ */
+
+// typedef struct ProcessTbl *ProcessTableRef;
+// typedef struct SimpleProcessTable *SimplyProcessTableRef;
+// typedef struct Hlground_Data Hlground_Data;
+// struct Hlground_Data {
+//   ProcessTableRef global_hlinks;  // global hlinks
+//   ProcessTableRef local_atoms;    // atoms within hlground
+// };
+//
 // Hlground_Data hlground_dat;a
-
-
-
-/*
-* extended ground
-*/
 
 void init_grounddata();
 void free_grounddata();
-void dfs_scope_finder(  ProcessTableRef *global_hlinks,
-                        ProcessTableRef *local_atoms,
-                        LinkObjRef root_link,
-                        Vector *src,
-                        Vector *avovec,
-                        ProcessTableRef *attr_functors,
-                        Vector *attr_dataAtoms,
-                        Vector *attr_dataAtom_attrs);
+void dfs_scope_finder(ProcessTableRef *global_hlinks,
+                      ProcessTableRef *local_atoms,
+                      LinkObjRef root_link,
+                      Vector *src, Vector *avovec,
+                      ProcessTableRef *attr_functors,
+                      Vector *attr_dataAtoms,
+                      Vector *attr_dataAtom_attrs);
 
 BOOL purecycle_exit(Vector *srcvec, Vector *avovec);
-BOOL cycle_exist (Vector *srcvec,
-				          Vector *avovec,
+BOOL cycle_exist (Vector *srcvec, Vector *avovec,
                   ProcessTableRef  *attr_functors,
                   Vector   *attr_dataAtoms,
-		              Vector   *attr_dataAtom_attrs);
+		  Vector   *attr_dataAtom_attrs);
 
 void get_neighbours(Vector  *avovec,
                     Vector *neighbours,
@@ -97,19 +97,15 @@ void get_neighbours(Vector  *avovec,
                     Vector   *attr_dataAtoms,
                     Vector   *attr_dataAtom_attrs);
 
-/*************************************/
-
-BOOL extended_ground_atoms( ProcessTableRef *global_hlinks,
-                            ProcessTableRef *local_atoms,
-                            Vector *srcvec,
-                            Vector *avovec,
-                            ProcessTableRef *atoms,
-                            ProcessTableRef *hlinks,
-                            ProcessTableRef *attr_functors,
-                            Vector *attr_dataAtoms,
-                            Vector *attr_dataAtom_attrs);
-
-
+BOOL extended_ground_atoms(ProcessTableRef *global_hlinks,
+                           ProcessTableRef *local_atoms,
+                           Vector *srcvec,
+                           Vector *avovec,
+                           ProcessTableRef *atoms,
+                           ProcessTableRef *hlinks,
+                           ProcessTableRef *attr_functors,
+                           Vector *attr_dataAtoms,
+                           Vector *attr_dataAtom_attrs);
 
 /** -----
  *  リンクオブジェクトの代替
@@ -150,9 +146,9 @@ BOOL lmn_mem_is_hlground(Vector *srcvec, Vector *avovec, unsigned long *natoms,
                          Vector *attr_dataAtom_attrs);
 void lmn_mem_copy_ground(LmnMembraneRef mem, Vector *srcvec,
                          Vector **ret_dstlovec, ProcessTableRef *ret_atommap,
-                           ProcessTableRef *ret_hlinkmap,
-                           ProcessTableRef *attr_functors,
-                           Vector *attr_dataAtoms, Vector *attr_dataAtom_attrs);
+                         ProcessTableRef *ret_hlinkmap,
+                         ProcessTableRef *attr_functors,
+                         Vector *attr_dataAtoms, Vector *attr_dataAtom_attrs);
 void lmn_mem_copy_hlground(LmnMembraneRef mem, Vector *srcvec,
                            Vector **ret_dstlovec, ProcessTableRef *ret_atommap,
                            ProcessTableRef *ret_hlinkmap,

--- a/src/vm/membrane.h
+++ b/src/vm/membrane.h
@@ -59,6 +59,58 @@ typedef struct LinkObj *LinkObjRef;
 
 #include <vector>
 
+
+/*
+ * Global variable
+ * */
+// Hlground_Data hlground_dat;a
+
+
+
+/*
+* extended ground
+*/
+
+void init_grounddata();
+void free_grounddata();
+void dfs_scope_finder(  ProcessTableRef *global_hlinks,
+                        ProcessTableRef *local_atoms,
+                        LinkObjRef root_link,
+                        Vector *src,
+                        Vector *avovec,
+                        ProcessTableRef *attr_functors,
+                        Vector *attr_dataAtoms,
+                        Vector *attr_dataAtom_attrs);
+
+BOOL purecycle_exit(Vector *srcvec, Vector *avovec);
+BOOL cycle_exist (Vector *srcvec,
+				          Vector *avovec,
+                  ProcessTableRef  *attr_functors,
+                  Vector   *attr_dataAtoms,
+		              Vector   *attr_dataAtom_attrs);
+
+void get_neighbours(Vector  *avovec,
+                    Vector *neighbours,
+                    LmnAtomRef atom,
+                    LmnLinkAttr pos,
+                    ProcessTableRef  *attr_functors,
+                    Vector   *attr_dataAtoms,
+                    Vector   *attr_dataAtom_attrs);
+
+/*************************************/
+
+BOOL extended_ground_atoms( ProcessTableRef *global_hlinks,
+                            ProcessTableRef *local_atoms,
+                            Vector *srcvec,
+                            Vector *avovec,
+                            ProcessTableRef *atoms,
+                            ProcessTableRef *hlinks,
+                            ProcessTableRef *attr_functors,
+                            Vector *attr_dataAtoms,
+                            Vector *attr_dataAtom_attrs);
+
+
+
 /** -----
  *  リンクオブジェクトの代替
  */
@@ -97,7 +149,10 @@ BOOL lmn_mem_is_hlground(Vector *srcvec, Vector *avovec, unsigned long *natoms,
                          ProcessTableRef *attr_functors, Vector *attr_dataAtoms,
                          Vector *attr_dataAtom_attrs);
 void lmn_mem_copy_ground(LmnMembraneRef mem, Vector *srcvec,
-                         Vector **ret_dstlovec, ProcessTableRef *ret_atommap);
+                         Vector **ret_dstlovec, ProcessTableRef *ret_atommap,
+                           ProcessTableRef *ret_hlinkmap,
+                           ProcessTableRef *attr_functors,
+                           Vector *attr_dataAtoms, Vector *attr_dataAtom_attrs);
 void lmn_mem_copy_hlground(LmnMembraneRef mem, Vector *srcvec,
                            Vector **ret_dstlovec, ProcessTableRef *ret_atommap,
                            ProcessTableRef *ret_hlinkmap,

--- a/src/vm/membrane.h
+++ b/src/vm/membrane.h
@@ -73,21 +73,21 @@ typedef struct LinkObj *LinkObjRef;
 //
 // Hlground_Data hlground_dat;a
 
-void init_grounddata();
-void free_grounddata();
+// void init_grounddata();
+// void free_grounddata();
 void dfs_scope_finder(ProcessTableRef *global_hlinks,
                       ProcessTableRef *local_atoms,
                       LinkObjRef root_link,
-                      Vector *src, Vector *avovec,
+                      // Vector *src, Vector *avovec,
                       ProcessTableRef *attr_functors,
                       Vector *attr_dataAtoms,
                       Vector *attr_dataAtom_attrs);
 
-BOOL purecycle_exit(Vector *srcvec, Vector *avovec);
-BOOL cycle_exist (Vector *srcvec, Vector *avovec,
-                  ProcessTableRef  *attr_functors,
-                  Vector   *attr_dataAtoms,
-		  Vector   *attr_dataAtom_attrs);
+BOOL purecycle_exist(Vector *srcvec, Vector *avovec);
+// BOOL cycle_exist (Vector *srcvec, Vector *avovec,
+//                   ProcessTableRef  *attr_functors,
+//                   Vector   *attr_dataAtoms,
+// 		  Vector   *attr_dataAtom_attrs);
 
 void get_neighbours(Vector  *avovec,
                     Vector *neighbours,
@@ -101,8 +101,8 @@ BOOL extended_ground_atoms(ProcessTableRef *global_hlinks,
                            ProcessTableRef *local_atoms,
                            Vector *srcvec,
                            Vector *avovec,
-                           ProcessTableRef *atoms,
-                           ProcessTableRef *hlinks,
+                           // ProcessTableRef *atoms,
+                           // ProcessTableRef *hlinks,
                            ProcessTableRef *attr_functors,
                            Vector *attr_dataAtoms,
                            Vector *attr_dataAtom_attrs);

--- a/src/vm/process_table.cpp
+++ b/src/vm/process_table.cpp
@@ -100,7 +100,7 @@ int ProcessTbl::put_new_mem(LmnMembraneRef mem, LmnWord value) {
 }
 
 /* テーブルからkeyとそれに対応した値を削除する.
- * 通常この間数ではなくunput_atom, unput_memを使用する. */
+ * 通常この関数ではなくunput_atom, unput_memを使用する. */
 void ProcessTbl::proc_tbl_unput(LmnWord key) { this->unput(key); }
 
 /* テーブルからアトムとそれに対応した値を削除する */
@@ -112,6 +112,11 @@ void ProcessTbl::unput_atom(LmnSymbolAtomRef atom) {
 void proc_tbl_unput_mem(ProcessTableRef p, LmnMembraneRef mem) {
   p->unput(mem);
 }
+
+void ProcessTbl::unput_hlink(HyperLink *hl) {  // extended
+  this->unput(hl);
+}
+
 
 /* テーブルのkeyに対応した値をvalueに設定し, 正の値を返す.
  * keyがテーブルに存在しない場合は0を返す. 通常この間数ではなくget_by_atom,

--- a/src/vm/process_table.cpp
+++ b/src/vm/process_table.cpp
@@ -175,10 +175,6 @@ BOOL proc_tbl_contains_mem(ProcessTableRef p, LmnMembraneRef mem) {
 }
 
 /* process table のダンプ，デバッグ用 */
-// int proc_tbl_item_dump(LmnWord k, LmnWord v, LmnWord _arg) {
-//   fprintf(stderr,"  key=%ld, value=%ld\n", k, v);
-//   return 1;
-// }
 void proc_tbl_dump(const char* name, ProcessTableRef map) {
   fprintf(stderr,"proc_tbl %s items:\n", name);
   map->tbl_foreach([](LmnWord k, LmnWord v, LmnWord _arg) {
@@ -188,11 +184,6 @@ void proc_tbl_dump(const char* name, ProcessTableRef map) {
 }
 
 /* シンボルアトムを入れた process table のダンプ，デバッグ用 */
-// int proc_tbl_symbol_atom_item_dump(LmnWord k, LmnWord v, LmnWord _arg) {
-//   LmnFunctor f = ((LmnSymbolAtomRef)v)->get_functor();
-//   fprintf(stderr,"  key=%ld, value=%s\n", k, LMN_FUNCTOR_STR(f));
-//   return 1;
-// }
 void proc_tbl_symbol_atom_dump(const char* name, ProcessTableRef map) {
   fprintf(stderr,"proc_tbl %s items:\n", name);
   map->tbl_foreach([](LmnWord k, LmnWord v, LmnWord _arg) {

--- a/src/vm/process_table.cpp
+++ b/src/vm/process_table.cpp
@@ -173,3 +173,31 @@ BOOL proc_tbl_contains_atom(ProcessTableRef p, LmnSymbolAtomRef atom) {
 BOOL proc_tbl_contains_mem(ProcessTableRef p, LmnMembraneRef mem) {
   return p->contains(mem);
 }
+
+/* process table のダンプ，デバッグ用 */
+// int proc_tbl_item_dump(LmnWord k, LmnWord v, LmnWord _arg) {
+//   fprintf(stderr,"  key=%ld, value=%ld\n", k, v);
+//   return 1;
+// }
+void proc_tbl_dump(const char* name, ProcessTableRef map) {
+  fprintf(stderr,"proc_tbl %s items:\n", name);
+  map->tbl_foreach([](LmnWord k, LmnWord v, LmnWord _arg) {
+		     fprintf(stderr,"  key=%ld, value=%ld\n", k, v);
+		     return 1;
+		   }, (LmnWord)0);
+}
+
+/* シンボルアトムを入れた process table のダンプ，デバッグ用 */
+// int proc_tbl_symbol_atom_item_dump(LmnWord k, LmnWord v, LmnWord _arg) {
+//   LmnFunctor f = ((LmnSymbolAtomRef)v)->get_functor();
+//   fprintf(stderr,"  key=%ld, value=%s\n", k, LMN_FUNCTOR_STR(f));
+//   return 1;
+// }
+void proc_tbl_symbol_atom_dump(const char* name, ProcessTableRef map) {
+  fprintf(stderr,"proc_tbl %s items:\n", name);
+  map->tbl_foreach([](LmnWord k, LmnWord v, LmnWord _arg) {
+		     LmnFunctor f = ((LmnSymbolAtomRef)v)->get_functor();
+		     fprintf(stderr,"  key=%ld, value=%s\n", k, LMN_FUNCTOR_STR(f));
+		     return 1;
+		   }, (LmnWord)0);
+}

--- a/src/vm/process_table.h
+++ b/src/vm/process_table.h
@@ -81,5 +81,7 @@ BOOL proc_tbl_contains(ProcessTableRef p, LmnWord key);
 BOOL proc_tbl_contains_atom(ProcessTableRef p, LmnSymbolAtomRef atom);
 BOOL proc_tbl_contains_mem(ProcessTableRef p, LmnMembraneRef mem);
 
+void proc_tbl_dump(const char* name, ProcessTableRef map);
+void proc_tbl_symbol_atom_dump(const char* name, ProcessTableRef map);
 
 #endif /* PROCESS_TABLE_H */

--- a/src/vm/process_table.h
+++ b/src/vm/process_table.h
@@ -62,6 +62,7 @@ struct ProcessTbl : ProcessTable<LmnWord> {
   int put_new_mem(LmnMembraneRef mem, LmnWord value);
   void proc_tbl_unput(LmnWord key);
   void unput_atom(LmnSymbolAtomRef atom);
+  void unput_hlink(HyperLink *hl);  // extended
 };
 
 /**

--- a/src/vm/rule.hpp
+++ b/src/vm/rule.hpp
@@ -106,7 +106,8 @@ public:
   LmnRule() : name(lmn_intern("")) {}
 
   ~LmnRule() {
-    delete (this->inst_seq);
+    // delete (this->inst_seq);
+    lmn_free(this->inst_seq);
   }
 
   void init_uniq_table() { is_unique_ = true; }

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -2655,6 +2655,7 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
       auto args = read_unary_atoms(rc, instr);
       b = ground_atoms(srcvec, avovec, atoms, &natoms);
     }
+    }
     Task::free_links(srcvec);
     Task::free_links(avovec);
 
@@ -2677,7 +2678,7 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
         });
       }
     }
-    }
+    
     break;
   }
   case INSTR_UNIQ: {
@@ -3955,9 +3956,6 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
       lmn_delete_atom(copy);
     }
 
-    // printf("deleting delmap: %d\n", delmap);
-    // delete delmap;   -- map should be deleted by a procedure pushed by COPYGROUND
-    // delmap = nullptr;  // ueda, quick fix
     break;
   }
   case INSTR_REMOVETOPLEVELPROXIES: {

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -2651,15 +2651,7 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
 
       // read hyperlink attributes though they are just ignored for ISGROUND
       auto args = read_unary_atoms(rc, instr);
-      // fprintf(stderr, "ISGROUND1, %d\n", args.size());
-      if (args.size() == 0) {
-        b = ground_atoms(srcvec, avovec, atoms, &natoms);
-      } else {
-        // fprintf(stderr, "ISGROUND with attr not yet implementedd\n", b); 	
-      // READ_VAL(LmnInstrVar, instr, n); // temporarily discard attr arg
-      
-      break;
-      }
+      b = ground_atoms(srcvec, avovec, atoms, &natoms);
     }
     Task::free_links(srcvec);
     Task::free_links(avovec);
@@ -3102,14 +3094,14 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
 	lmn_mem_copy_ground((LmnMembraneRef)rc->wt(memi), srcvec, &dstlovec,
                             // &atommap);
 			    &atommap, NULL, NULL, NULL, NULL);  // extended
-      } else {              // extended bround
+      } else {              // extended ground
 	ProcessTableRef attr_functors;
 	Vector attr_dataAtoms;
 	Vector attr_dataAtom_attrs;
 	attr_dataAtoms.init(16);
 	attr_dataAtom_attrs.init(16);
 	attr_functors = new ProcessTbl(16);
-	LmnInstrVar i = 0, n;
+	LmnInstrVar i = 0;
 
         for (; n--; i++) {
           LmnLinkAttr attr;
@@ -3125,13 +3117,13 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
             attr_functors->proc_tbl_put(f, f);
           }
         }
+        // fprintf(stderr, "lmn_mem_copy_ground starts\n");
 	lmn_mem_copy_ground((LmnMembraneRef)rc->wt(memi), srcvec, &dstlovec,
                             // &atommap);
 			    &atommap, &hlinkmap, &attr_functors,     // extended
 			    &attr_dataAtoms, &attr_dataAtom_attrs);  // extended
+        // fprintf(stderr, "lmn_mem_copy_ground ended\n");
       }
-
-      
 
       break;
     }

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -2648,7 +2648,10 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
     }
     case INSTR_ISGROUND: {
       LmnInstrVar n;
-      READ_VAL(LmnInstrVar, instr, n); // temporarily discard attr arg
+
+      // read hyperlink attributes though they are just ignored for ISGROUND
+      auto args = read_unary_atoms(rc, instr);
+      // READ_VAL(LmnInstrVar, instr, n); // temporarily discard attr arg
       b = ground_atoms(srcvec, avovec, atoms, &natoms);
       break;
     }
@@ -3083,7 +3086,10 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
     }
     case INSTR_COPYGROUND:
       LmnInstrVar n;
-      READ_VAL(LmnInstrVar, instr, n); // temporarily discard attr arg
+
+      // read hyperlink attributes
+      auto args = read_unary_atoms(rc, instr);
+      // READ_VAL(LmnInstrVar, instr, n); // temporarily discard attr arg
       lmn_mem_copy_ground((LmnMembraneRef)rc->wt(memi), srcvec, &dstlovec,
                           &atommap);
       break;

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -2651,11 +2651,13 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
 
       // read hyperlink attributes though they are just ignored for ISGROUND
       auto args = read_unary_atoms(rc, instr);
+      // fprintf(stderr, "ISGROUND1, %d\n", args.size());
       if (args.size() == 0) {
+        b = ground_atoms(srcvec, avovec, atoms, &natoms);
       } else {
-	
+        // fprintf(stderr, "ISGROUND with attr not yet implementedd\n", b); 	
       // READ_VAL(LmnInstrVar, instr, n); // temporarily discard attr arg
-      b = ground_atoms(srcvec, avovec, atoms, &natoms);
+      
       break;
       }
     }

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -3141,7 +3141,7 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
 
     this->push_stackframe([=](interpreter &itr, bool result) {
       Task::free_links(dstlovec);
-      printf("finalizing, atommap: %d\n", atommap);
+      // printf("finalizing, atommap: %d\n", atommap);
       // proc_tbl_symbol_atom_dump("atommap", atommap);
 
       delete atommap; // ueda
@@ -3955,9 +3955,9 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
       lmn_delete_atom(copy);
     }
 
-    printf("deleting delmap: %d\n", delmap);
-    delete delmap;
-    delmap = nullptr;  // ueda, quick fix
+    // printf("deleting delmap: %d\n", delmap);
+    // delete delmap;   -- map should be deleted by a procedure pushed by COPYGROUND
+    // delmap = nullptr;  // ueda, quick fix
     break;
   }
   case INSTR_REMOVETOPLEVELPROXIES: {

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -2647,6 +2647,8 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
       break;
     }
     case INSTR_ISGROUND: {
+      LmnInstrVar n;
+      READ_VAL(LmnInstrVar, instr, n); // temporarily discard attr arg
       b = ground_atoms(srcvec, avovec, atoms, &natoms);
       break;
     }
@@ -3080,6 +3082,8 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
       break;
     }
     case INSTR_COPYGROUND:
+      LmnInstrVar n;
+      READ_VAL(LmnInstrVar, instr, n); // temporarily discard attr arg
       lmn_mem_copy_ground((LmnMembraneRef)rc->wt(memi), srcvec, &dstlovec,
                           &atommap);
       break;


### PR DESCRIPTION
0. 比較的大規模な改修を伴うブランチです．もう少し改修を切り分けることも不可能ではないですがとりあえずこの形で置きます．
1. 簡単な例についてvalgrindでメモリリークのないことを確認しました（さまざまなメモリリークを見つけて直しました）．
2. このために多数の free および delete を追加もしくは（malloc/new に対応させるために）変更しています．
3. また valgrind のために -g オプションでコンパイルされるように configure.ac を変更していますが，特に支障がない限り -g は入れたままにしておくことを提案します．
4. 追いかけるのが難しいエラーがいくつも出たので，現時点では大量のデバッグプリントをコメントアウトして残してあります（これまで何度もアンコメントして再利用しました）．
5. extended ground機能（属性つきハイパーリンクのコピー／共有の制御ができるground）のマージが主目的でしたが，それと一見無関係なunify命令のバグ（通常リンクとハイパーリンクとの結合時に発生）を発見して修正しました．
6. このバグはハイパーグラフ構造のill-formedness（ちゃんとした相棒のないリンクの存在）を引き起こすものですが，相棒リンクをたどる機会がないと出現せず，発見が遅れます．このため，-d コマンドを指定すると使われる開発者用dump_cell_devに，相棒リンク (buddy) のチェック機能を組み込みました．記号アトムとハイパーリンクアトムの各リンクについて相棒を表示し，逆写像になっていないと ****ILL-FORMED**** というメッセージが出ます．
7. ハイパーリンクの番号を16進で出力する機能と10進で出力する機能が混在していたので，暫定的に10進に統一しました．