### PR TITLE
make toplevel cons atom to print with an equal atom (e.g. [1,2,3|X] = X)

### DIFF
--- a/src/vm/dumper.cpp
+++ b/src/vm/dumper.cpp
@@ -442,6 +442,17 @@ static BOOL dump_symbol_atom(LmnPortRef port, LmnSymbolAtomRef atom,
     return dump_atom(port, atom->get_link(0), ht,
                      atom->get_attr(0), s, 1);
   }
+  // トップレベルに cons ('.') が出現した場合は，
+  // [1, 2, 3 | X] = X のようにイコールアトムで繋いで [] （角括弧） を用いて出力する．
+  if (call_depth == 0 &&
+      f == LMN_LIST_FUNCTOR) { 
+    t->done = FALSE;
+    const BOOL result = dump_list(port, atom, ht, s, 0);
+    port_put_raw_s(port, " = ");
+    dump_arg(port, atom, 2, ht, s, 1);
+    return result;
+  }
+
   dump_atomname(port, f);
   dump_atom_args(port, atom, ht, s, call_depth);
   return TRUE;

--- a/src/vm/dumper.cpp
+++ b/src/vm/dumper.cpp
@@ -434,6 +434,17 @@ static BOOL dump_symbol_atom(LmnPortRef port, LmnSymbolAtomRef atom,
 
   if (t->done)
     return FALSE;
+  
+  // トップレベルに cons ('.') が出現した場合は，
+  // `[1,2,3|X]=X` のようにイコールアトムで繋いで [] （角括弧） を用いて出力する．
+  if (call_depth == 0 &&
+      f == LMN_LIST_FUNCTOR) { 
+    dump_list(port, atom, ht, s, 0);
+    port_put_raw_s(port, "=");
+    dump_arg(port, atom, 2, ht, s, 1);
+    return TRUE;
+  }
+
   t->done = TRUE;
 
   if (call_depth == 0 &&
@@ -442,17 +453,6 @@ static BOOL dump_symbol_atom(LmnPortRef port, LmnSymbolAtomRef atom,
     return dump_atom(port, atom->get_link(0), ht,
                      atom->get_attr(0), s, 1);
   }
-  // トップレベルに cons ('.') が出現した場合は，
-  // [1, 2, 3 | X] = X のようにイコールアトムで繋いで [] （角括弧） を用いて出力する．
-  if (call_depth == 0 &&
-      f == LMN_LIST_FUNCTOR) { 
-    t->done = FALSE;
-    const BOOL result = dump_list(port, atom, ht, s, 0);
-    port_put_raw_s(port, " = ");
-    dump_arg(port, atom, 2, ht, s, 1);
-    return result;
-  }
-
   dump_atomname(port, f);
   dump_atom_args(port, atom, ht, s, call_depth);
   return TRUE;


### PR DESCRIPTION
# make toplevel cons atom to print with an equal atom (e.g. [1,2,3|X] = X)
## 概要
issue #207 の toplevel の cons atom の pretty print の改善を行いました．

```
X=[1,2,3|X]. 
```
を slim に渡すと，
```
[1,2,3|X] = X. 
```
と pretty print します．
リストを後ろ側に表示する（この例での入力）のは，現状では難しいと思うので，この辺りが妥当なラインかなと．

## 懸念（修正すべき部分）

`dump_list` などの `BOOL` の戻り値の意味をよくわかっていないので，謎なコードになっている．

ちゃんとわかっている人に聞いた方が良いかも．

## 上記以外にテストしたもの：

```
[4,5,6]=[1,2,3].
```

他に何かあるかな？
