### PR TITLE
fix src/element/lmnstring.cpp cb_string_split

### DIFF
--- a/src/element/lmnstring.cpp
+++ b/src/element/lmnstring.cpp
@@ -170,7 +170,17 @@ void cb_string_split(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
   auto ls = std::vector<std::string>();
 
   if(sep_len == 0) {
-    ls.push_back(split_str);
+    auto str_len = split_str.length();
+    auto offset = std::string::size_type(0);
+    while (1) {
+      if(offset < str_len) {
+        ls.push_back(split_str.substr(offset,1));
+        offset++;
+      } else {
+        break;
+      }
+    }
+    /* ls.push_back(split_str); */
   } else {
     auto offset = std::string::size_type(0);
     while (1) {

--- a/src/element/lmnstring.cpp
+++ b/src/element/lmnstring.cpp
@@ -160,6 +160,11 @@ void cb_string_replace(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
   lmn_mem_delete_atom(mem, a2, t2);
 }
 
+/*
+ *  2021/10/02
+ *    分割文字として空文字が入力された際の挙動を、
+ *    lib/string.lmnに記載されている通り、一文字ずつ分割するように修正
+ */
 void cb_string_split(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
                       LmnLinkAttr t0, LmnAtomRef a1, LmnLinkAttr t1,
                       LmnAtomRef a2, LmnLinkAttr t2) {
@@ -169,19 +174,11 @@ void cb_string_split(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
   auto sep_len = sep_str.length();
   auto ls = std::vector<std::string>();
 
-  if(sep_len == 0) {
+  if(sep_len == 0) {          // 分割文字として空文字が入力された場合は一文字ずつ分割する
+    int i;
     auto str_len = split_str.length();
-    auto offset = std::string::size_type(0);
-    while (1) {
-      if(offset < str_len) {
-        ls.push_back(split_str.substr(offset,1));
-        offset++;
-      } else {
-        break;
-      }
-    }
-    /* ls.push_back(split_str); */
-  } else {
+    for (i = 0; i < str_len; i++) ls.push_back(split_str.substr(i,1));
+  } else {          // 分割文字が空文字以外に設定されている場合は分割文字の位置で分割する（分割文字は飛ばす）
     auto offset = std::string::size_type(0);
     while (1) {
       auto pos = split_str.find(sep_str, offset);

--- a/src/element/lmnstring.cpp
+++ b/src/element/lmnstring.cpp
@@ -161,23 +161,20 @@ void cb_string_replace(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
 }
 
 /*
- *  2021/10/02
- *    分割文字として空文字が入力された際の挙動を、
- *    lib/string.lmnに記載されている通り、一文字ずつ分割するように修正
+ *    string型文字列を指定した分割文字をもとに分割し、リストの要素に変換する
+ *    lib/string.lmn の string.split から利用出来る
  */
 void cb_string_split(LmnReactCxtRef rc, LmnMembraneRef mem, LmnAtomRef a0,
                       LmnLinkAttr t0, LmnAtomRef a1, LmnLinkAttr t1,
                       LmnAtomRef a2, LmnLinkAttr t2) {
 
-  auto split_str = reinterpret_cast<LmnString *>(a0)->str;
-  auto sep_str = reinterpret_cast<LmnString *>(a1)->str;
+  auto split_str = reinterpret_cast<LmnString *>(a0)->str;  //入力文字列
+  auto sep_str = reinterpret_cast<LmnString *>(a1)->str;    //分割文字(列)
   auto sep_len = sep_str.length();
   auto ls = std::vector<std::string>();
 
   if(sep_len == 0) {          // 分割文字として空文字が入力された場合は一文字ずつ分割する
-    int i;
-    auto str_len = split_str.length();
-    for (i = 0; i < str_len; i++) ls.push_back(split_str.substr(i,1));
+    for (auto i = 0; i < split_str.length(); i++) ls.push_back(split_str.substr(i,1));
   } else {          // 分割文字が空文字以外に設定されている場合は分割文字の位置で分割する（分割文字は飛ばす）
     auto offset = std::string::size_type(0);
     while (1) {


### PR DESCRIPTION
stringライブラリで定義されているstring_splitについて、分割文字として空文字を設定した場合に、
入力されたstring型を一文字ずつに分割したリスト型を返すように変更しました。