### PR TITLE
bugfix issue-279

### DIFF
--- a/src/loader/il_lexer.cpp.re
+++ b/src/loader/il_lexer.cpp.re
@@ -114,7 +114,7 @@ start:
 
     digit = [0-9];
     integer = digit+;
-    exponent = [e|E][-|+]?integer;
+    exponent = [eE][-+]?integer;
     blank = [ \t\n\r];
 
     sstr = "'"  [^']* "'";

--- a/src/loader/il_lexer.cpp.re
+++ b/src/loader/il_lexer.cpp.re
@@ -113,6 +113,8 @@ start:
     re2c:define:YYFILL:naked = 1;
 
     digit = [0-9];
+    integer = digit+;
+    exponent = [e|E][-|+]?integer;
     blank = [ \t\n\r];
 
     sstr = "'"  [^']* "'";
@@ -126,7 +128,7 @@ start:
       yylval->as<int>() = s.empty() ? 0 : stol(s);
       return parser::token::INT;
     }
-    '-'?digit+"."digit+ {
+    '-'?integer("."integer)?exponent? {
       yylval->as<double>() = stod(get_token());
       return parser::token::FLOAT;
     }


### PR DESCRIPTION
#279 の問題を解消しました。
コンパイル時に、`1.0E-4` のような指数表現が用いられた場合、lexer がそれを認識できない問題を解決しました。