### PR TITLE
added --show-laststep-only option

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -142,6 +142,7 @@ LmnEnv::LmnEnv() {
   this->output_format = DEFAULT;
   this->mc_dump_format = CUI;
   this->sp_dump_format = SP_NONE;
+  this->show_laststep_only = FALSE;
   this->nd = FALSE;
   this->ltl = FALSE;
   this->ltl_all = FALSE;

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -142,7 +142,6 @@ LmnEnv::LmnEnv() {
   this->output_format = DEFAULT;
   this->mc_dump_format = CUI;
   this->sp_dump_format = SP_NONE;
-  this->show_laststep_only = FALSE;
   this->nd = FALSE;
   this->ltl = FALSE;
   this->ltl_all = FALSE;

--- a/src/lmntal.h
+++ b/src/lmntal.h
@@ -328,6 +328,8 @@ struct LmnEnv {
   BOOL shuffle_rule;
   BOOL shuffle_atom;
   
+  BOOL show_laststep_only;
+
   enum OutputFormat output_format;
   enum MCdumpFormat mc_dump_format;
   enum SPdumpFormat sp_dump_format;

--- a/src/lmntal.h
+++ b/src/lmntal.h
@@ -328,8 +328,6 @@ struct LmnEnv {
   BOOL shuffle_rule;
   BOOL shuffle_atom;
   
-  BOOL show_laststep_only;
-
   enum OutputFormat output_format;
   enum MCdumpFormat mc_dump_format;
   enum SPdumpFormat sp_dump_format;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -181,7 +181,6 @@ static void parse_options(int *optid, int argc, char *argv[]) {
                                   {"dump-json", 0, 0, 1105},
                                   {"dump-fsm-lmn-detail", 0, 0, 1106},
                                   {"dump-fsm-hl", 0, 0, 1107},
-                                  {"show-laststep-only", 0, 0, 1108},
                                   {"interactive", 0, 0, 1200},
                                   {"translate", 0, 0, 1300},
                                   {"hl", 0, 0, 1350},
@@ -332,10 +331,6 @@ static void parse_options(int *optid, int argc, char *argv[]) {
       break;
     case 1107:
       lmn_env.mc_dump_format = LMN_FSM_GRAPH_HL_NODE;
-      break;
-    case 1108:
-      lmn_env.trace = TRUE;
-      lmn_env.show_laststep_only = TRUE;
       break;
     case 1200: /* jni interactive mode */
 #ifdef HAVE_JNI_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -181,6 +181,7 @@ static void parse_options(int *optid, int argc, char *argv[]) {
                                   {"dump-json", 0, 0, 1105},
                                   {"dump-fsm-lmn-detail", 0, 0, 1106},
                                   {"dump-fsm-hl", 0, 0, 1107},
+                                  {"show-laststep-only", 0, 0, 1108},
                                   {"interactive", 0, 0, 1200},
                                   {"translate", 0, 0, 1300},
                                   {"hl", 0, 0, 1350},
@@ -331,6 +332,10 @@ static void parse_options(int *optid, int argc, char *argv[]) {
       break;
     case 1107:
       lmn_env.mc_dump_format = LMN_FSM_GRAPH_HL_NODE;
+      break;
+    case 1108:
+      lmn_env.trace = TRUE;
+      lmn_env.show_laststep_only = TRUE;
       break;
     case 1200: /* jni interactive mode */
 #ifdef HAVE_JNI_H

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -199,13 +199,17 @@ void Task::lmn_run(Vector *start_rulesets) {
   mrc->memstack_reconstruct(mem);
 
   if (lmn_env.trace) {
-    if (lmn_env.output_format != JSON) {
+    if (lmn_env.show_laststep_only) {
       mrc->increment_reaction_count();
-      fprintf(stdout, "%d: ", mrc->get_reaction_count());
+    } else {
+      if (lmn_env.output_format != JSON) {
+        mrc->increment_reaction_count();
+        fprintf(stdout, "%d: ", mrc->get_reaction_count());
+      }
+      lmn_dump_cell_stdout(mem);
+      if (lmn_env.show_hyperlink)
+          lmn_hyperlink_print(mem);
     }
-    lmn_dump_cell_stdout(mem);
-    if (lmn_env.show_hyperlink)
-      lmn_hyperlink_print(mem);
   }
 
   mem_oriented_loop(mrc.get(), mem);
@@ -222,6 +226,7 @@ void Task::lmn_run(Vector *start_rulesets) {
     if (lmn_env.sp_dump_format == LMN_SYNTAX) {
       fprintf(stdout, "finish.\n");
     } else {
+      if (lmn_env.show_laststep_only) fprintf(stdout, "%d: ", mrc->get_reaction_count());
       lmn_dump_cell_stdout(mem);
     }
   }
@@ -409,6 +414,8 @@ BOOL Task::react_rule(LmnReactCxtRef rc, LmnMembraneRef mem, LmnRuleRef rule) {
         rc->increment_reaction_count();
       } else if (lmn_env.output_format == JSON) {
         lmn_dump_cell_stdout(rc->get_global_root());
+      } else if (lmn_env.show_laststep_only) {
+        rc->increment_reaction_count();
       } else {
         fprintf(stdout, "---->%s\n", lmn_id_to_name(rule->name));
         rc->increment_reaction_count();

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -199,17 +199,13 @@ void Task::lmn_run(Vector *start_rulesets) {
   mrc->memstack_reconstruct(mem);
 
   if (lmn_env.trace) {
-    if (lmn_env.show_laststep_only) {
+    if (lmn_env.output_format != JSON) {
       mrc->increment_reaction_count();
-    } else {
-      if (lmn_env.output_format != JSON) {
-        mrc->increment_reaction_count();
-        fprintf(stdout, "%d: ", mrc->get_reaction_count());
-      }
-      lmn_dump_cell_stdout(mem);
-      if (lmn_env.show_hyperlink)
-          lmn_hyperlink_print(mem);
+      fprintf(stdout, "%d: ", mrc->get_reaction_count());
     }
+    lmn_dump_cell_stdout(mem);
+    if (lmn_env.show_hyperlink)
+      lmn_hyperlink_print(mem);
   }
 
   mem_oriented_loop(mrc.get(), mem);
@@ -226,7 +222,6 @@ void Task::lmn_run(Vector *start_rulesets) {
     if (lmn_env.sp_dump_format == LMN_SYNTAX) {
       fprintf(stdout, "finish.\n");
     } else {
-      if (lmn_env.show_laststep_only) fprintf(stdout, "%d: ", mrc->get_reaction_count());
       lmn_dump_cell_stdout(mem);
     }
   }
@@ -414,8 +409,6 @@ BOOL Task::react_rule(LmnReactCxtRef rc, LmnMembraneRef mem, LmnRuleRef rule) {
         rc->increment_reaction_count();
       } else if (lmn_env.output_format == JSON) {
         lmn_dump_cell_stdout(rc->get_global_root());
-      } else if (lmn_env.show_laststep_only) {
-        rc->increment_reaction_count();
       } else {
         fprintf(stdout, "---->%s\n", lmn_id_to_name(rule->name));
         rc->increment_reaction_count();

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -199,13 +199,17 @@ void Task::lmn_run(Vector *start_rulesets) {
   mrc->memstack_reconstruct(mem);
 
   if (lmn_env.trace) {
-    if (lmn_env.output_format != JSON) {
+    if (lmn_env.show_laststep_only) {
       mrc->increment_reaction_count();
-      fprintf(stdout, "%d: ", mrc->get_reaction_count());
+    } else {
+      if (lmn_env.output_format != JSON) {
+        mrc->increment_reaction_count();
+        fprintf(stdout, "%d: ", mrc->get_reaction_count());
+      }
+      lmn_dump_cell_stdout(mem);
+      if (lmn_env.show_hyperlink)
+        lmn_hyperlink_print(mem);
     }
-    lmn_dump_cell_stdout(mem);
-    if (lmn_env.show_hyperlink)
-      lmn_hyperlink_print(mem);
   }
 
   mem_oriented_loop(mrc.get(), mem);
@@ -222,6 +226,7 @@ void Task::lmn_run(Vector *start_rulesets) {
     if (lmn_env.sp_dump_format == LMN_SYNTAX) {
       fprintf(stdout, "finish.\n");
     } else {
+      if (lmn_env.show_laststep_only) fprintf(stdout, "%d: ", mrc->get_reaction_count());
       lmn_dump_cell_stdout(mem);
     }
   }
@@ -411,6 +416,8 @@ BOOL Task::react_rule(LmnReactCxtRef rc, LmnMembraneRef mem, LmnRuleRef rule) {
         rc->increment_reaction_count();
       } else if (lmn_env.output_format == JSON) {
         lmn_dump_cell_stdout(rc->get_global_root());
+      } else if (lmn_env.show_laststep_only) {
+        rc->increment_reaction_count();
       } else {
         fprintf(stdout, "---->%s\n", lmn_id_to_name(rule->name));
         rc->increment_reaction_count();


### PR DESCRIPTION
#268 のオプションを追加しました.
オプション名は"--show-laststep-only", LmnEnv上では"show_laststep_only"です.
最終状態のダンプ直前に最終ステップ数を表示します.
(実行例：
% ./src/slim -t --show-laststep-only ~/Workspace/LaViT2_9_1/demo/append.lmn 
7: ret([1,2,3,4,5,6,7]). @4.
% ./src/slim --show-laststep-only ~/Workspace/LaViT2_9_1/demo/append.lmn 
7: ret([1,2,3,4,5,6,7]). @4.)