### PR TITLE
autoconf のバージョン問題に暫定対応

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: sudo apt -qq update
-    - run: sudo apt install -y ant re2c
+    - run: sudo apt install -y ant re2c autoconf2.69
     - run: git clone https://github.com/lmntal/lmntal-compiler.git
     - run: cd lmntal-compiler && ant && cd ..
     - run: ./autogen.sh

--- a/autogen.sh
+++ b/autogen.sh
@@ -14,7 +14,7 @@ run ()
 # makeshift
 autoheader=autoheader
 autoreconf=autoreconf
-autoconf --version | grep 2.69
+autoconf --version | grep 2.69 &>/dev/null
 if test $? != 0 ; then
   echo "autoconf 2.69 is not installed."
   echo "Trying to use autoconf2.69 instead."

--- a/autogen.sh
+++ b/autogen.sh
@@ -11,7 +11,18 @@ run ()
   fi
 }
 
+# makeshift
+autoheader=autoheader
+autoreconf=autoreconf
+autoconf --version | grep 2.69
+if test $? != 0 ; then
+  echo "autoconf 2.69 is not installed."
+  echo "Trying to use autoconf2.69 instead."
+  autoheader=autoheader2.69
+  autoreconf=autoreconf2.69
+fi
+
 run aclocal
-run autoheader
+run $autoheader
 run automake --add-missing
-run autoreconf
+run $autoreconf


### PR DESCRIPTION
`apt` で `autoconf2.69` というパッケージが配られていることを発見したので、Ubuntu 22系では暫定的にそちらを使ってもらうのが良いかと思いました。
Ubuntu 20系のaptでautoconf 2.71が配られるまでは、全員向けに2.71を強いるのは厳しいので。

`autoconf --version` が2.69でない場合、自動的に `autoconf2.69` を試すように `autogen.sh` を書き換えました。
一応Ubuntu20系・22系双方で動くことを確認済みです。
22系ではちょっとwarningが出ますが、make checkまで動きます。