### PR TITLE
fix: update mem stack

### DIFF
--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -1059,6 +1059,35 @@ struct exec_subinstructions_branch {
   }
 };
 
+static bool push_updated_hl_cmems
+( LmnMembraneRef mem,
+  std::vector<LmnMembraneRef> &buf, int id )
+{
+  bool is_updated = false;
+  for (auto *cmem = mem->child_head; cmem; cmem = cmem->next) {
+    /* 子膜側に再帰 */
+    bool updated_hl = push_updated_hl_cmems( cmem, buf, id );
+
+    /* 現在の膜の検査. 子膜側に変化があったら冗長のためskip */
+    auto *ent = cmem->get_atomlist( LMN_HL_FUNC );
+    if (!updated_hl) {
+      LmnSymbolAtomRef atom;
+      EACH_ATOM( atom, ent, {
+          auto hl_id = LMN_HL_ID( LMN_HL_ATOM_ROOT_HL( atom ) );
+          updated_hl = (hl_id == id);
+          if (updated_hl) break;
+        });
+    }
+
+    /* 変化があった場合, 当該膜をメモしておく */
+    if (updated_hl) {
+      buf.push_back( cmem );
+      is_updated = true;
+    }
+  }
+  return is_updated;
+}
+
 /**
  *  execute a command at instr.
  *  instr is incremented by the size of operation.
@@ -2967,6 +2996,14 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
       lmn_mem_delete_atom(m, (LmnAtomRef)rc->wt(atomi), rc->at(atomi));
       lmn_mem_delete_atom(m, atom1, (LmnWord)attr1);
       lmn_mem_delete_atom(m, atom2, (LmnWord)attr2);
+
+      if (rc->has_mode(REACT_MEM_ORIENTED) && hl1 && hl1->get_root()) {
+        std::vector<LmnMembraneRef> mbuf;/* memstackの逆順 */
+        push_updated_hl_cmems( m, mbuf, LMN_HL_ID( hl1->get_root() ) );
+        /* stackの逆順に親子関係が並んでいるので, 逆順にstackへ積む */
+        for (int i = (int)mbuf.size()-1; i >= 0; i--)
+          ((MemReactContext *)rc)->memstack_push( mbuf[i] );
+      }
     }
     break;
   }


### PR DESCRIPTION
close #11

- 膜を貫く HL が膜の外で併合したときに，その併合の影響を受ける膜を実行膜stack に載せることで膜に対するルールが発火する