### PR TITLE
Fix compile errors in environments without atomic operation.

### DIFF
--- a/src/element/error.cpp
+++ b/src/element/error.cpp
@@ -40,10 +40,16 @@
 #include "lmntal.h"
 #include <stdarg.h>
 #include <stdlib.h>
+#include <cstdlib>
 
 void do_lmn_fatal(const char *file, int line, const char *msg) {
   fprintf(stderr, "%s(%d) %s\n", file, line, msg);
   fflush(stderr);
+#ifdef DEBUG
+  assert(false);
+#else
+  exit(EXIT_FAILURE);
+#endif
 }
 
 void lmn_report(const char *msg, ...) {

--- a/src/element/error.cpp
+++ b/src/element/error.cpp
@@ -42,7 +42,8 @@
 #include <stdlib.h>
 #include <cstdlib>
 
-void do_lmn_fatal(const char *file, int line, const char *msg) {
+[[noreturn]]
+int do_lmn_fatal(const char *file, int line, const char *msg) {
   fprintf(stderr, "%s(%d) %s\n", file, line, msg);
   fflush(stderr);
 #ifdef DEBUG

--- a/src/element/error.h
+++ b/src/element/error.h
@@ -44,24 +44,10 @@
 
 #include "lmntal.h"
 
-#include <cstdlib>
-
 /* Error */
-#ifdef DEBUG
-#define lmn_fatal(Msg)                                                         \
-  do {                                                                         \
-    do_lmn_fatal(__FILE__, __LINE__, Msg);                                     \
-    assert(FALSE);                                                             \
-  } while (0);
-#else
-#define lmn_fatal(Msg)                                                         \
-  do {                                                                         \
-    do_lmn_fatal(__FILE__, __LINE__, Msg);                                     \
-    exit(EXIT_FAILURE);                                                        \
-  } while (0);
-#endif
+#define lmn_fatal(Msg) do_lmn_fatal(__FILE__, __LINE__, Msg);
 
-void do_lmn_fatal(const char *file, int line, const char *msg);
+LMN_EXTERN void do_lmn_fatal(const char *file, int line, const char *msg);
 LMN_EXTERN void lmn_report(const char *msg, ...);
 
 /* @} */

--- a/src/element/error.h
+++ b/src/element/error.h
@@ -45,9 +45,10 @@
 #include "lmntal.h"
 
 /* Error */
-#define lmn_fatal(Msg) do_lmn_fatal(__FILE__, __LINE__, Msg);
+#define lmn_fatal(Msg) do_lmn_fatal(__FILE__, __LINE__, Msg)
 
-LMN_EXTERN void do_lmn_fatal(const char *file, int line, const char *msg);
+[[noreturn]]
+LMN_EXTERN int do_lmn_fatal(const char *file, int line, const char *msg);
 LMN_EXTERN void lmn_report(const char *msg, ...);
 
 /* @} */

--- a/src/element/lmntal_thread.h
+++ b/src/element/lmntal_thread.h
@@ -57,25 +57,25 @@
                           成功したら真を返す */
 #define CAS(A, B, C) __sync_bool_compare_and_swap(&(A), B, C)
 #else
-#define CAS(A, B, C) lmn_fatal("disable ATOMIC OPERATION, unexpected.");
+#define CAS(A, B, C) lmn_fatal("disable ATOMIC OPERATION, unexpected.")
 #endif /* HAVE_ATOMIC_CAS */
 #
 #ifdef HAVE_ATOMIC_ADD /* AにBを加算し, 加算後のAの値を返す */
 #define ADD_AND_FETCH(A, B) __sync_add_and_fetch(&(A), B)
 #else
-#define ADD_AND_FETCH(A, B) lmn_fatal("disable ATOMIC OPERATION, unexpected.");
+#define ADD_AND_FETCH(A, B) lmn_fatal("disable ATOMIC OPERATION, unexpected.")
 #endif /* HAVE_ATOMIC_ADD */
 #
 #ifdef HAVE_ATOMIC_SUB
 #define SUB_AND_FETCH(A, B) __sync_sub_and_fetch(&(A), B)
 #else
-#define SUB_AND_FETCH(A, B) lmn_fatal("disable ATOMIC OPERATION, unexpected.");
+#define SUB_AND_FETCH(A, B) lmn_fatal("disable ATOMIC OPERATION, unexpected.")
 #endif /* HAVE_ATOMIC_SUB */
 #
 #ifdef HAVE_ATOMIC_LOGICAL_AND
 #define AND_AND_FETCH(A, B) __sync_and_and_fetch(&(A), B)
 #else
-#define AND_AND_FETCH(A, B) lmn_fatal("disable ATOMIC OPERATION, unexpected.");
+#define AND_AND_FETCH(A, B) lmn_fatal("disable ATOMIC OPERATION, unexpected.")
 #endif /* HAVE_ATOMIC_LOGICAL_AND */
 #
 #ifdef HAVE_ATOMIC_LOGICAL_OR

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -101,7 +101,7 @@ void env_my_TLS_finalize() {
   env_set_my_thread_id(LMN_PRIMARY_ID); /* resetする */
 #elif defined(USE_TLS_PTHREAD_KEY)
   if (env_my_thread_id() != LMN_PRIMARY_ID) {
-    lmn_TLS_free(lmn_TLS_get_value(lmn_tls));
+    lmn_TLS_free((LmnTLS *)lmn_TLS_get_value(lmn_tls));
   }
 #endif
 }
@@ -128,7 +128,7 @@ void lmn_stream_destroy() {
 #if !defined(ENABLE_PARALLEL) || defined(USE_TLS_KEYWORD)
   lmn_TLS_destroy(&lmn_tls);
 #elif defined(USE_TLS_PTHREAD_KEY)
-  lmn_TLS_free(lmn_TLS_get_value(lmn_tls));
+  lmn_TLS_free((LmnTLS *)lmn_TLS_get_value(lmn_tls));
   lmn_TLS_key_destroy(lmn_tls);
 #endif
 }


### PR DESCRIPTION
組み込みAtomic命令がない環境において、以下のマクロ
```c++
#ifdef HAVE_ATOMIC_LOGICAL_OR
#define OR_AND_FETCH(A, B) __sync_or_and_fetch(&(A), B)
#else
#define OR_AND_FETCH(A, B) lmn_fatal("disable ATOMIC OPERATION, unexepcted.")
#endif /* HAVE_ATOMIC_LOGICAL_OR */
```
が式として使用された時に `lmn_fatal` マクロが文として展開されるためコンパイルエラーになる問題の解消。
`lmn_fatal` マクロを単純な関数呼び出しに変更し、式として利用できるようにした。

型検査的な問題は残るのと、そもそも c++11 なら std::atomic が使えるので環境に左右されるコンパイラの組み込み命令よりもそちらを使うようにしたほうが良い。