### PR TITLE
Add --tr env flag to show applied rules' name

### DIFF
--- a/src/env.cpp
+++ b/src/env.cpp
@@ -136,6 +136,7 @@ void lmn_stream_destroy() {
 /* lmn_env構造体の初期化 */
 LmnEnv::LmnEnv() {
   trace = FALSE;
+  this->trace_rule_name_only = FALSE;
   this->show_proxy = FALSE;
   this->show_chr = FALSE;
   this->show_ruleset = TRUE;

--- a/src/lmntal.h
+++ b/src/lmntal.h
@@ -228,6 +228,7 @@ enum OptimizeMode { OPT_NONE, OPT_MINIMIZE, OPT_MAXIMIZE };
 
 struct LmnEnv {
   BOOL trace;
+  BOOL trace_rule_name_only;
   BOOL show_proxy;
   BOOL show_ruleset;
   BOOL show_chr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,6 +85,8 @@ static void usage(void) {
       "from LMNtal\n"
       "  -t                   (RT) Show execution path\n"
       "                       (MC) Show state space\n"
+      "  --tr                 (RT) Show only applied rule names\n"
+      "                       (MC) Show applied rule names with application counts\n"
       "  --hide-ruleset       Hide ruleset from result\n"
       "  --shuffle-rule       (RT) Apply rules randomly\n"
       "  --shuffle-atom       (RT) Choose atoms to be applied randomly\n"
@@ -243,6 +245,7 @@ static void parse_options(int *optid, int argc, char *argv[]) {
                                   {"shuffle-atom",0,0,6081},
                                   {"shuffle",0,0,6082},
                                   {"interactive-debug", 0, 0, 6090},
+                                  {"tr", 0, 0, 6091},
                                   {0, 0, 0, 0}};
 
   while ((c = getopt_long(argc, argv, "+dvhtI:O::p::", long_options,
@@ -609,6 +612,9 @@ static void parse_options(int *optid, int argc, char *argv[]) {
       break;
     case 6090:
       lmn_env.interactive_debug = TRUE;
+      break;
+    case 6091:
+      lmn_env.trace_rule_name_only = TRUE;
       break;
     case 'I':
       lmn_env.load_path[lmn_env.load_path_num++] = optarg;

--- a/src/verifier/mc.cpp
+++ b/src/verifier/mc.cpp
@@ -47,6 +47,7 @@
 #include "runtime_status.h"
 #ifdef DEBUG
 #include "vm/dumper.h"
+#include "vm/task.h"
 #endif
 #include "state.h"
 #include "state.hpp"
@@ -165,7 +166,7 @@ static void mc_dump(LmnWorkerGroup *wp) {
     ss->format_states();
 
     /* 1. 状態遷移グラフの標準出力 */
-    if (lmn_env.trace) {
+    if (lmn_env.trace && !lmn_env.trace_rule_name_only) {
       ss->dump();
     }
 
@@ -206,6 +207,9 @@ static void mc_dump(LmnWorkerGroup *wp) {
     lmn_prof.has_property = TRUE;
   if (wp->workers_have_error())
     lmn_prof.found_err = TRUE;
+
+  if (lmn_env.trace_rule_name_only)
+    Task::print_rule_apply_count();
 }
 
 /** =====================================================

--- a/src/verifier/mc.cpp
+++ b/src/verifier/mc.cpp
@@ -207,7 +207,7 @@ static void mc_dump(LmnWorkerGroup *wp) {
   if (wp->workers_have_error())
     lmn_prof.found_err = TRUE;
 
-  if (lmn_env.trace_rule_name_only)
+  if (lmn_env.dump && lmn_env.trace_rule_name_only)
     Task::print_rule_apply_count();
 }
 

--- a/src/verifier/mc.cpp
+++ b/src/verifier/mc.cpp
@@ -47,7 +47,6 @@
 #include "runtime_status.h"
 #ifdef DEBUG
 #include "vm/dumper.h"
-#include "vm/task.h"
 #endif
 #include "state.h"
 #include "state.hpp"

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -54,7 +54,9 @@
 
 #include <algorithm>
 #include <iostream>
+#include <mutex>
 #include <unordered_map>
+#include <vector>
 typedef void (*callback_0)(LmnReactCxtRef, LmnMembraneRef);
 typedef void (*callback_1)(LmnReactCxtRef, LmnMembraneRef, LmnAtomRef,
                            LmnLinkAttr);
@@ -92,10 +94,20 @@ typedef void (*callback_8)(LmnReactCxtRef, LmnMembraneRef, LmnAtomRef,
 struct Vector user_system_rulesets; /* system ruleset defined by user */
 
 static std::unordered_map<lmn_interned_str, unsigned int> rule_apply_count;
+static std::mutex rule_apply_count_mutex;
 
 void Task::print_rule_apply_count() {
+  if (lmn_env.output_format == JSON) return;
+  std::vector<std::pair<lmn_interned_str, unsigned int>> sorted(
+      rule_apply_count.begin(), rule_apply_count.end());
+  std::sort(sorted.begin(), sorted.end(),
+            [](const std::pair<lmn_interned_str, unsigned int> &a,
+               const std::pair<lmn_interned_str, unsigned int> &b) {
+              return std::string(lmn_id_to_name(a.first)) <
+                     std::string(lmn_id_to_name(b.first));
+            });
   fprintf(stdout, "\n[Applied Rules]\n");
-  for (auto &kv : rule_apply_count)
+  for (auto &kv : sorted)
     fprintf(stdout, "%s: %u\n", lmn_id_to_name(kv.first), kv.second);
   rule_apply_count.clear();
 }
@@ -450,6 +462,7 @@ BOOL Task::react_rule(LmnReactCxtRef rc, LmnMembraneRef mem, LmnRuleRef rule) {
 
   if (lmn_env.trace_rule_name_only && result && !rc->is_zerostep
       && rule->name != ANONYMOUS
+      && lmn_env.output_format != JSON
       && (rc->has_mode(REACT_MEM_ORIENTED) || rc->has_mode(REACT_ND))) {
     fprintf(stdout, "---> %s\n", lmn_id_to_name(rule->name));
   }
@@ -1319,8 +1332,10 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
       auto mcrc = dynamic_cast<MCReactContext *>(rc);
       ProcessID org_next_id = env_next_id();
 
-      if (lmn_env.trace_rule_name_only && rule->name != ANONYMOUS)
+      if (lmn_env.trace_rule_name_only && rule->name != ANONYMOUS) {
+        std::lock_guard<std::mutex> lock(rule_apply_count_mutex);
         rule_apply_count[rule->name]++;
+      }
 
       if (mcrc->has_optmode(DeltaMembrane)) {
         /** >>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<< **/

--- a/src/vm/task.cpp
+++ b/src/vm/task.cpp
@@ -53,7 +53,8 @@
 #endif
 
 #include <algorithm>
-#include <iostream> 
+#include <iostream>
+#include <unordered_map>
 typedef void (*callback_0)(LmnReactCxtRef, LmnMembraneRef);
 typedef void (*callback_1)(LmnReactCxtRef, LmnMembraneRef, LmnAtomRef,
                            LmnLinkAttr);
@@ -89,6 +90,15 @@ typedef void (*callback_8)(LmnReactCxtRef, LmnMembraneRef, LmnAtomRef,
                            LmnLinkAttr, LmnAtomRef, LmnLinkAttr);
 
 struct Vector user_system_rulesets; /* system ruleset defined by user */
+
+static std::unordered_map<lmn_interned_str, unsigned int> rule_apply_count;
+
+void Task::print_rule_apply_count() {
+  fprintf(stdout, "\n[Applied Rules]\n");
+  for (auto &kv : rule_apply_count)
+    fprintf(stdout, "%s: %u\n", lmn_id_to_name(kv.first), kv.second);
+  rule_apply_count.clear();
+}
 
 /**
   Javaによる処理系ではリンクはリンクオブジェクトで表現するが、SLIMでは
@@ -223,7 +233,7 @@ void Task::lmn_run(Vector *start_rulesets) {
     InteractiveDebugger::get_instance().start_session_on_entry();
   }
 
-  if (lmn_env.trace) {
+  if (lmn_env.trace && !lmn_env.trace_rule_name_only) {
     if (lmn_env.show_laststep_only) {
       mrc->increment_reaction_count();
     } else {
@@ -249,9 +259,7 @@ void Task::lmn_run(Vector *start_rulesets) {
     InteractiveDebugger::get_instance().finish_debugging();
   }
 
-  if (lmn_env
-          .dump) { /* lmntalではioモジュールがあるけど必ず実行結果を出力するプログラミング言語,
-                      で良い?? */
+  if (lmn_env.dump) {
     if (lmn_env.sp_dump_format == LMN_SYNTAX) {
       fprintf(stdout, "finish.\n");
     } else {
@@ -440,8 +448,14 @@ BOOL Task::react_rule(LmnReactCxtRef rc, LmnMembraneRef mem, LmnRuleRef rule) {
 
   profile_finish_trial();
 
+  if (lmn_env.trace_rule_name_only && result && !rc->is_zerostep
+      && rule->name != ANONYMOUS
+      && (rc->has_mode(REACT_MEM_ORIENTED) || rc->has_mode(REACT_ND))) {
+    fprintf(stdout, "---> %s\n", lmn_id_to_name(rule->name));
+  }
+
   if (rc->has_mode(REACT_MEM_ORIENTED) && !rc->is_zerostep) {
-    if (lmn_env.trace && result) {
+    if (lmn_env.trace && result && !lmn_env.trace_rule_name_only) {
       if (lmn_env.sp_dump_format == LMN_SYNTAX) {
         lmn_dump_mem_stdout(rc->get_global_root());
         fprintf(stdout, ".\n");
@@ -1304,6 +1318,9 @@ bool slim::vm::interpreter::exec_command(LmnReactCxt *rc, LmnRuleRef rule,
     if (rc->has_mode(REACT_ND) && !rc->is_zerostep) {
       auto mcrc = dynamic_cast<MCReactContext *>(rc);
       ProcessID org_next_id = env_next_id();
+
+      if (lmn_env.trace_rule_name_only && rule->name != ANONYMOUS)
+        rule_apply_count[rule->name]++;
 
       if (mcrc->has_optmode(DeltaMembrane)) {
         /** >>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<< **/

--- a/src/vm/task.h
+++ b/src/vm/task.h
@@ -89,6 +89,7 @@ public:
   static void react_start_rulesets(LmnMembraneRef mem, Vector *rulesets);
   static BOOL react_all_rulesets(LmnReactCxtRef rc, LmnMembraneRef cur_mem);
   static struct Vector user_system_rulesets; /* system ruleset defined by user */ //ユーザーが書く部分となるとpublicにしておかざるを得ない
+  static void print_rule_apply_count();
   static HashSet *insertconnectors(slim::vm::RuleContext *rc, LmnMembraneRef mem,
                             const Vector *links);
 


### PR DESCRIPTION
- Adds option `--tr` to show rules applied for the program. 

### deterministic mode

- `--tr` shows results like:
```log
❯ slim --tr ../lavit/demo/append.lmn                                                                                                                                                  
---> _appe
---> _appe
---> _appe
---> _appe
---> _appe
---> _appe
ret([1,2,3,4,5,6,7]). @58.
```

- `-t` shows results like:
``` log
❯ slim -t ../lavit/demo/append.lmn                                                                                                                                                           
1: ret(append([1,2,3,4,5],[6,7])). @58.
---->_appe
2: ret([1|append([2,3,4,5],[6,7])]). @58.
---->_appe
3: ret([1,2|append([3,4,5],[6,7])]). @58.
---->_appe
4: ret([1,2,3|append([4,5],[6,7])]). @58.
---->_appe
5: ret([1,2,3,4|append([5],[6,7])]). @58.
---->_appe
6: ret([1,2,3,4,5|append([],[6,7])]). @58.
---->_appe
7: ret([1,2,3,4,5,6,7]). @58.
ret([1,2,3,4,5,6,7]). @58.
```

### non-deterministic mode

- `--tr` shows results like:
```log
❯ slim --nd --tr ../lavit/demo/lambda_nd.lmn                                                                                                                                                 
'# of States'(stored)   = 940.
'# of States'(end)      = 2.

[Applied Rules]
promote: 364
gc: 159
c_c1: 574
c_c2: 327
l_c: 124
beta: 1042
a_c: 331
c2c: 35
_Nn2N: 8
```